### PR TITLE
Added loading bar and label to show progress to the loading screen which fixes #136

### DIFF
--- a/content/gui/xml/mainmenu/loadingscreen.xml
+++ b/content/gui/xml/mainmenu/loadingscreen.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0"?>
-<Container size="1024,768">
+<Container name="loadingScreen" size="1024,768">
 	<Icon image="content/gui/images/buttons/mainmenu_bg.png" />
 	<Icon image="content/gui/images/background/mainmenu/loading.png" position="387,316" />
-	<Label name="loading_label" position="400,360"
-		text="Loading ..." font="libertine_large_load"
-		max_size="250,50" min_size="150,50" />
+	<Label name="loading" position="410,340"
+		text="loading..." font="libertine_large_load"
+		max_size="150,100" min_size="300,100" />
+
+	<VBox position="410,390" >
+	<ProgressBar name="progressBar" />
+	</VBox>
+
+	<Label name="percentage" position="500,384"
+		font="libertine_mainmenu"
+		max_size="150,50" min_size="80,70" />
 	<Label name="version_label" position="745,735"
 		text="Unknown Horizons Alpha" font="libertine_mainmenu" />
 </Container>

--- a/horizons/gui/gui.py
+++ b/horizons/gui/gui.py
@@ -64,6 +64,7 @@ class Gui(SingleplayerMenu, MultiplayerMenu):
 		self.widgets = LazyWidgetsDict(self.styles) # access widgets with their filenames without '.xml'
 		self.session = None
 		self.current_dialog = None
+		Gui.self = self
 
 # basic menu widgets
 
@@ -330,7 +331,21 @@ class Gui(SingleplayerMenu, MultiplayerMenu):
 		return popup
 
 	def show_loading_screen(self):
-		self._switch_current_widget('loadingscreen', center=True, show=True)
+		"""Shows the loading screen with progress bar and precentage labels vaules of 0"""
+		Gui.self._switch_current_widget('loadingscreen', center=True, show=True)
+		self.update_loading_screen(0)
+
+	@staticmethod
+	def set_progress(progress_value):
+		"""Sets the progress value.
+		@param progress_value: int, progress value for islands loading"""
+		Gui.self.update_loading_screen(progress_value)
+
+	def update_loading_screen(self, progress_value):
+		"""Updates the loading screen widgets with the new progress value.
+		@param progress_value: int, progress value for islands loading"""
+		Gui.self.current.findChild(name="progressBar")._set_progress(progress_value)
+		Gui.self.current.findChild(name="percentage").text = unicode(progress_value)
 
 # helper
 

--- a/horizons/world/island.py
+++ b/horizons/world/island.py
@@ -22,6 +22,7 @@
 import weakref
 import logging
 import re
+import horizons.gui
 
 from horizons.entities import Entities
 from horizons.scheduler import Scheduler
@@ -305,9 +306,21 @@ class Island(BuildingOwner, WorldObject):
 			except KeyError:
 				pass
 
+	ground_number = 0
 	def __iter__(self):
+		total = float(len(self.ground_map)) # total number of grounds, we need to know to calculate progress values
+		old_progress = 0
+
 		for i in self.get_coordinates():
 			yield i
+			
+			# calculate progress values and sends them to update the loading screen
+			self.ground_number += 1
+			progress = int((self.ground_number/total) * 100)
+			if old_progress < progress:
+				horizons.gui.Gui.set_progress(progress)
+				old_progress = progress
+		self.ground_number = 0 # resets the number of grounds for each map
 
 	def check_wild_animal_population(self):
 		"""Creates a wild animal if they died out."""
@@ -321,4 +334,5 @@ class Island(BuildingOwner, WorldObject):
 					return
 		# we might not find a tree, but if that's the case, wild animals would die out anyway again,
 		# so do nothing in this case.
+
 


### PR DESCRIPTION
I added a progress bar and percentage label widgets to the loading screen and provided them with the progress values from world/island.py module but there is a problem regarding redrawing of the loading screen, please have a look on it.
