### PR TITLE
refs #811 : Campaigns

### DIFF
--- a/content/campaign/test.yaml
+++ b/content/campaign/test.yaml
@@ -1,0 +1,26 @@
+scenarios:
+- # Level 1
+  level: sc1
+  conditions: 
+
+- # Level 2
+  level: sc2
+  goals:
+   - goal[1]
+     set_var [xy], [1]
+   - goal[2]
+     set_var [za], [5]
+     do_something_other ["for further ideas..."]
+  conditions: 
+   - goal_reached [1] [0]
+
+- # Level 3
+  level: sc3
+  conditions: 
+   - goal_reached [1] [1]
+   - goal_reached [2] [1]
+
+difficulty: easy
+author: court-jus
+description: |
+ The test campaign.

--- a/content/scenarios/sc1.yaml
+++ b/content/scenarios/sc1.yaml
@@ -1,0 +1,19 @@
+author: The UH team
+description: "Campaign 1 :\nBe a player ...\n"
+difficulty: !!python/unicode 'Didacticiel'
+events:
+- actions:
+  - arguments: ["First scneario of the campagin."]
+    type: message
+  conditions:
+  - arguments: [1]
+    type: time_passed
+- actions:
+  - {type: win}
+  - arguments: [!!python/unicode 'Congratulations!']
+    type: message
+  conditions:
+  - arguments: [3]
+    type: time_passed
+mapfile: development.sqlite
+

--- a/content/scenarios/sc2.yaml
+++ b/content/scenarios/sc2.yaml
@@ -1,0 +1,19 @@
+author: The UH team
+description: "Campaign 2 :\nBe a mayor.\n"
+difficulty: !!python/unicode 'Didacticiel'
+events:
+- actions:
+  - arguments: ["Second scneario of the campagin."]
+    type: message
+  conditions:
+  - arguments: [1]
+    type: time_passed
+- actions:
+  - {type: win}
+  - arguments: [!!python/unicode 'Congratulations!']
+    type: message
+  conditions:
+  - arguments: [3]
+    type: time_passed
+mapfile: development.sqlite
+

--- a/content/scenarios/sc3.yaml
+++ b/content/scenarios/sc3.yaml
@@ -1,0 +1,19 @@
+author: The UH team
+description: "Campaign 3 :\nBe a king !\n"
+difficulty: !!python/unicode 'Didacticiel'
+events:
+- actions:
+  - arguments: ["Third scneario of the campagin."]
+    type: message
+  conditions:
+  - arguments: [1]
+    type: time_passed
+- actions:
+  - {type: win}
+  - arguments: [!!python/unicode 'Congratulations! Campaign finished !']
+    type: message
+  conditions:
+  - arguments: [3]
+    type: time_passed
+mapfile: development.sqlite
+

--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -292,3 +292,4 @@ LANGUAGENAMES = _LanguageNameDict(
 	sl    = u'Slovenski',
 	)
 LANGUAGENAMES['ca@valencia'] = u'Català' # need to do this if @ sign in po file name
+AUTO_CONTINUE_CAMPAIGN=True

--- a/horizons/gui/modules/singleplayermenu.py
+++ b/horizons/gui/modules/singleplayermenu.py
@@ -63,7 +63,7 @@ class SingleplayerMenu(object):
 			else: # scenario
 				del eventMap['showScenario']
 				self.current.findChild(name="showScenario").marked = True
-				self.current.files, maps_display = SavegameManager.get_scenarios()
+				self.current.files, maps_display = SavegameManager.get_available_scenarios()
 
 			# get the map files and their display names
 			self.current.distributeInitialData({ 'maplist' : maps_display, })

--- a/horizons/session.py
+++ b/horizons/session.py
@@ -92,6 +92,7 @@ class Session(LivingObject):
 		self.view = View(self, (15, 15))
 		Entities.load(self.db)
 		self.scenario_eventhandler = ScenarioEventHandler(self) # dummy handler with no events
+		self.campaign = {}
 
 		#GUI
 		self.gui.session = self
@@ -158,7 +159,7 @@ class Session(LivingObject):
 	def save(self, savegame):
 		raise NotImplementedError
 
-	def load(self, savegame, players, is_scenario=False):
+	def load(self, savegame, players, is_scenario=False, campaign={}):
 		"""Loads a map.
 		@param savegame: path to the savegame database.
 		@param players: iterable of dictionaries containing id, name, color and local
@@ -169,6 +170,7 @@ class Session(LivingObject):
 			self.scenario_eventhandler = ScenarioEventHandler(self, savegame)
 			savegame = os.path.join(SavegameManager.maps_dir, \
 			                        self.scenario_eventhandler.get_map_file())
+		self.campaign = campaign
 
 		self.log.debug("Session: Loading from %s", savegame)
 		savegame_db = DbReader(savegame) # Initialize new dbreader

--- a/run_uh.py
+++ b/run_uh.py
@@ -96,6 +96,8 @@ def get_option_parser():
 							 type="int", metavar="<seed>", help=_("Starts a random map with seed <seed>."))
 	start_uh_group.add_option("--start-scenario", dest="start_scenario", metavar="<scenario>", \
 														help=_("Starts <scenario>. <scenario> is the scenarioname."))
+	start_uh_group.add_option("--start-campaign", dest="start_campaign", metavar="<campaign>", \
+														help=_("Starts <campaign>. <campaign> is the campaign name."))
 	start_uh_group.add_option("--start-dev-map", dest="start_dev_map", action="store_true", \
 			default=False, help=_("Starts the development map without displaying the main menu."))
 	start_uh_group.add_option("--load-map", dest="load_map", metavar="<save>", \


### PR DESCRIPTION
- We describe campaigns in a yaml file (see content/campaign/test.yaml).
- The availability of the scenarios are held in the campaign_status.yaml
  file in the user's save game directory.
- We start a campaign with the --start-campaign=campaign_name option
- When the current scenario is won, the next one is made available and
  automatically loaded if the AUTO_CONTINUE_CAMPAIGN constant is True

TODO : we should have a "start campaign" menu and UI
TODO : we shouldn't make the NEXT scenario available but
       the scenarios that depend on the current scenario
       victory
TODO : if the scenario is loaded outside of the campaign
       should it be marked as won for every campaign that
       contains it ?
TODO : present a scenario choosing Gui to the user after
       a victory
