### PR TITLE
Added execute_many to DbReader

### DIFF
--- a/horizons/util/dbreader.py
+++ b/horizons/util/dbreader.py
@@ -54,6 +54,13 @@ class DbReader(object):
 		@params, return: same as in __call__"""
 		return self(command, *args)
 
+	def execute_many(self, command, parameters):
+		"""Executes a sql command for each sequence or mapping
+		found in parameters.
+		@param command: same as in __call__
+		@param parameters: sequence or iterator"""
+		return self.cur.executemany(command, parameters)
+
 	def execute_script(self, script):
 		"""Executes a multiline script.
 		@param script: multiline str containing an sql script."""


### PR DESCRIPTION
sqlite3.Cursor.executemany executes a single command for multiple
parameter sequences, e.g. allowing to insert multiple rows with one
call.

---

I'm working on tests, and to be able to fill an empty database with data on a per-test-basis, this will be more readable than issuing multiple queries. Using execute_script doesn't help in my case, because it'll run a COMMIT before which effectively will end my transaction.
