### PR TITLE
Fixed error when loading a game fails because of .DS_Store files in the content directory

### DIFF
--- a/horizons/util/loaders/actionsetloader.py
+++ b/horizons/util/loaders/actionsetloader.py
@@ -48,7 +48,7 @@ class ActionSetLoader(object):
 			if entry.startswith("as_"):
 				cls.action_sets[entry] = GeneralLoader._load_action(full_path)
 			else:
-				if os.path.isdir(full_path) and entry != ".svn":
+				if os.path.isdir(full_path) and entry != ".svn" and entry != ".DS_Store":
 					cls._find_action_sets(full_path)
 
 	@classmethod

--- a/horizons/util/loaders/loader.py
+++ b/horizons/util/loaders/loader.py
@@ -65,7 +65,9 @@ class GeneralLoader(object):
 		rotations = {}
 		time = 500
 		dirs = os.listdir(dir)
-		try: dirs.remove('.svn')
+		try: 
+			dirs.remove('.svn')
+			dirs.remove('.DS_Store')
 		except ValueError: pass
 
 		for dirname in dirs:
@@ -77,8 +79,9 @@ class GeneralLoader(object):
 			try:
 				rotations[int(dirname)] = cls._load_files(os.path.join(dir, dirname),time)
 			except Exception, e:
-				raise Exception("Failed to load action sets from %s with time %d: %s" % \
-				                (os.path.join(dir, dirname), time, e))
+				if dirname != '.DS_Store':
+					raise Exception("Failed to load action sets from %s with time %d: %s" % \
+				                	(os.path.join(dir, dirname), time, e))
 
 		return rotations
 
@@ -92,10 +95,13 @@ class GeneralLoader(object):
 		"""
 		actions = {}
 		dirs = os.listdir(dir)
-		try: dirs.remove('.svn')
+		try: 
+			dirs.remove('.svn')
+			dirs.remove('.DS_Store')
 		except ValueError: pass
 
 		for dirname in dirs:
-			actions[dirname] = cls._load_rotation(os.path.join(dir, dirname))
+			if dirname != '.DS_Store':
+				actions[dirname] = cls._load_rotation(os.path.join(dir, dirname))
 
 		return actions

--- a/horizons/util/loaders/tilesetloader.py
+++ b/horizons/util/loaders/tilesetloader.py
@@ -48,7 +48,7 @@ class TileSetLoader(object):
 			if entry.startswith("ts_"):
 				cls.tile_sets[entry] = GeneralLoader._load_action(full_path)
 			else:
-				if os.path.isdir(full_path) and entry != ".svn":
+				if os.path.isdir(full_path) and entry != ".svn" and entry != ".DS_Store":
 					cls._find_tile_sets(full_path)
 
 	@classmethod


### PR DESCRIPTION
Fixed a Error that caused a Crash on Mac while loading a new or saved Game. 

Because of the .DS_Store files in the content directories that are created by the system. 
