### PR TITLE
Make scheduler tests work with python 2.6 + impl fix

### DIFF
--- a/horizons/scheduler.py
+++ b/horizons/scheduler.py
@@ -159,7 +159,7 @@ class Scheduler(LivingObject):
 		removed_objs = 0
 		if self.schedule is not None:
 			for key in self.schedule:
-				for i in xrange(0, self.schedule[key].count(callback_obj)):
+				while callback_obj in self.schedule[key]:
 					self.schedule[key].remove(callback_obj)
 					self.calls_by_instance[callback_obj.class_instance].remove(callback_obj)
 					removed_objs += 1

--- a/tests/unittests/test_scheduler.py
+++ b/tests/unittests/test_scheduler.py
@@ -59,15 +59,17 @@ class TestScheduler(TestCase):
 		self.assertEqual(3, self.scheduler.cur_tick)
 
 	def test_fail_when_missing_start_tick(self):
-		self.scheduler.before_ticking()
-		with self.assertRaises(Exception):
+		def tick():
 			self.scheduler.tick(2)
+		self.scheduler.before_ticking()
+		self.assertRaises(Exception, tick)
 
 	def test_fail_when_same_tick_twice(self):
+		def tick():
+			self.scheduler.tick(1)
 		self.scheduler.before_ticking()
 		self.scheduler.tick(1)
-		with self.assertRaises(Exception):
-			self.scheduler.tick(1)
+		self.assertRaises(Exception, tick)
 
 	def test_add_callback_before_first_tick(self):
 		self.scheduler.add_new_object(self.callback, None, run_in=0)


### PR DESCRIPTION
Now actually tested that it works on my machine with 2.6 :-)
