### PR TITLE
Update horizons/session.py

### DIFF
--- a/horizons/session.py
+++ b/horizons/session.py
@@ -128,7 +128,7 @@ class Session(LivingObject):
 		self.status_icon_manager = StatusIconManager(self)
 
 		self.selected_instances = set()
-		self.selection_groups = [set()] * 10 # List of sets that holds the player assigned unit groups.
+		self.selection_groups = [set() for _ in range(10)]  # List of sets that holds the player assigned unit groups.
 
 		self._old_autosave_interval = None
 


### PR DESCRIPTION
The problem is here

```
self.selection_groups = [set()] * 10
```

set() is mutable so i think it's a bug.
The list contains 10 references to the same object

```
>>> a = [set()] * 10
>>> a[0].add(5)
>>> a
[set([5]), set([5]), set([5]), set([5]), set([5]), set([5]), set([5]), set([5]), set([5]), set([5])]
```
