### PR TITLE
Development

### DIFF
--- a/horizons/gui/modules/singleplayermenu.py
+++ b/horizons/gui/modules/singleplayermenu.py
@@ -136,7 +136,7 @@ class SingleplayerMenu(object):
 					u"please contact us via our website (http://www.unknown-horizons.org)!"
 				self.show_popup("No campaigns available yet", text)
 			elif show == 'scenario':
-				self.current.files, maps_display = SavegameManager.get_available_scenarios(locales = choosable_locales)
+				self.current.files, maps_display = SavegameManager.get_available_scenarios()
 				# get the map files and their display names. display tutorials on top.
 				prefer_tutorial = lambda x : ('tutorial' not in x, x)
 				maps_display.sort(key=prefer_tutorial)

--- a/horizons/main.py
+++ b/horizons/main.py
@@ -47,7 +47,6 @@ from horizons.constants import AI, COLORS, GAME, PATHS, NETWORK, SINGLEPLAYER, G
 from horizons.network.networkinterface import NetworkInterface
 from horizons.util import ActionSetLoader, DifficultySettings, TileSetLoader, Color, parse_port, Callback
 from horizons.util.uhdbaccessor import UhDbAccessor
-from horizons.i18n import find_available_languages
 
 # private module pointers of this module
 class Modules(object):
@@ -394,30 +393,7 @@ def _start_map(map_name, ai_players=0, human_ai=False, is_scenario=False, campai
 	"""Start a map specified by user
 	@param map_name: name of map or path to map
 	@return: bool, whether loading succeded"""
-	#if map is a scenario then set mapnames and paths with language extensions
-	#these lines e.g. change "tutorial" to "tutorial_en" and
-	#"content/scenarios/tutorial" to "content/scenarios/tutorial_en.yaml"
-	if is_scenario:
-		#get all available scenarios
-		maps = SavegameManager.get_available_scenarios()
-		#get all available languages
-		languages = find_available_languages().keys()
-		scenario_map_paths = []
-		scenario_map_names = []
-		#we will use "content/scenarios/tutorial_en.yaml" instead of content/scenarios/tutorial" as map_path
-		for mappath in maps[0]:
-			for language in languages:
-				scenario_map_paths.append(mappath + '_' + language + '.' + SavegameManager.scenario_extension)
-		#we will use "tutorial_en" instead of "tutorial"
-		for mapname in maps[1]:
-			for language in languages:
-				scenario_map_names.append(mapname + '_' + language + '.' + SavegameManager.scenario_extension)
-
-		#now we have scenario map extensions/maps with language extensions
-		maps = (scenario_map_paths, scenario_map_names)
-
-	else:
-		maps = SavegameManager.get_maps()
+	maps = SavegameManager.get_available_scenarios(locales=True) if is_scenario else SavegameManager.get_maps()
 
 	map_file = None
 

--- a/horizons/savegamemanager.py
+++ b/horizons/savegamemanager.py
@@ -28,9 +28,11 @@ import glob
 import time
 import re
 import yaml
+import itertools
 
 from horizons.constants import PATHS, VERSION
 from horizons.util import DbReader, YamlCache
+from horizons.i18n import find_available_languages
 
 import horizons.main
 
@@ -317,7 +319,7 @@ class SavegameManager(object):
 		return cls.__get_saves_from_dirs([cls.scenarios_dir], include_displaynames, cls.scenario_extension, False)
 
 	@classmethod
-	def get_available_scenarios(cls, include_displaynames = True, locales = None):
+	def get_available_scenarios(cls, include_displaynames = True, locales = False):
 		"""Returns available scenarios (depending on the campaign(s) status)"""
 		afiles = []
 		anames = []
@@ -335,6 +337,26 @@ class SavegameManager(object):
 				if not sname in anames:
 					anames.append(sname)
 					afiles.append(sfiles[i][:sfiles[i].rfind(cur_locale)])
+
+		def _list_maps_with_language(prefixlist, language):
+			maplist = []
+			for (listitem, language) in itertools.product(prefixlist, languages):
+				maplist.append(listitem + '_' + language + '.' + SavegameManager.scenario_extension)
+
+			return maplist
+
+		#we use scenario map name + language extension
+		languages = find_available_languages().keys()
+		#we use full map paths (with language extensions)
+		scenario_map_paths = _list_maps_with_language(afiles, languages)
+		#we use full map names (with language extensions)
+		scenario_map_names = _list_maps_with_language(anames, languages)
+
+		#if needed we should return with language extensions
+		if locales:
+			afiles = scenario_map_paths
+			anames = scenario_map_names
+
 		if not include_displaynames:
 			return (afiles,)
 		return (afiles, anames)


### PR DESCRIPTION
fixes bug #1709 [1]

With this commit a scenario map can be started without using its language extension

e.g. "--start-scenario tutorial" is enough (language will be the language of the game)

[1] http://trac.unknown-horizons.org/t/ticket/1709
