### PR TITLE
Don't crash if no persistant cache file can be opened

### DIFF
--- a/horizons/util/yamlcache.py
+++ b/horizons/util/yamlcache.py
@@ -187,7 +187,14 @@ class YamlCache(object):
 			cls.log.exception("Warning: You probably have an old cache file; deleting and retrying: "+unicode(e))
 			if os.path.exists(cls.cache_filename):
 				os.remove(cls.cache_filename)
-			cls.cache = shelve.open(cls.cache_filename)
+			try:
+				cls.cache = shelve.open(cls.cache_filename)
+			except Exception as e:
+				# If no persistant cache can be opened the game should still be
+				# playable and not just crash.
+				cls.log.exception("Warning: Failed to open %s as cache: %s" % (
+									cls.cache_filename, unicode(e)))
+				cls.cache = DummyShelve()
 		cls.lock.release()
 
 


### PR DESCRIPTION
If no persistant cache file can be opened, the game retries and then
crashes. Imho the game should still be playable even if the startup
takes a little longer - at least it is playable at all.
On the down side we might not get as many crashes reported and a real
bug might get hidden. Still I think it's worth it.

This might also "fix" the problem with the mac package if there isn't a bigger one underneath.
