### PR TITLE
fife path setup in run_uh

### DIFF
--- a/run_uh.py
+++ b/run_uh.py
@@ -439,12 +439,8 @@ def is_fife_path(path):
 		os.path.join('engine', 'python', 'fife'),
 		os.path.join('engine', 'python', 'fife', 'extensions'))
 
-	for d in directories:
-		d = os.path.join(absolute_path, d)
-		if not os.path.exists(d):
-			return False
-
-	return True
+	return all(os.path.exists(os.path.join(absolute_path, d))
+				for d in directories)
 
 
 def restart_with_fife(fife_custom_path=None):


### PR DESCRIPTION
Here is something I'd like to discuss since some time:
    The names of all functions having to do with finding FIFE in run_uh
    had nearly the same meaning, although they had different purposes. To
    make it clearer, what the code is doing, all functions get exacter
    names and same functionality isn't scattered through different
    functions that much any more.

There are still some questions about what the code does and should do marked with FIXMEs. So **please don't pull this until the FIXMEs are gone.**
