### PR TITLE
Test for new fisher selection crash

### DIFF
--- a/tests/gui/ingame/test_build.py
+++ b/tests/gui/ingame/test_build.py
@@ -101,4 +101,26 @@ def test_found_settlement(gui):
 		yield
 	assert ground_map[(55, 15)].object is None
 
+	# open build menu again
+	gui.trigger('mainhud', 'build/action/default')
+
+	# build a fisher
+	gui.trigger('tab', 'button_33/action/default')
+	gui.cursor_click(60, 4, 'left')
+	fisher = ground_map[(60, 4)].object
+	assert(fisher.id == BUILDINGS.FISHER)
+
+	# connect the lumberjack and fisher using a road
+	gui.trigger('tab', 'button_21/action/default')
+	for x in xrange(57, 60):
+		gui.cursor_click(x, 5, 'left')
+		assert(ground_map[(x, 5)].object.id == BUILDINGS.TRAIL)
+	gui.cursor_click(x, 5, 'right')
+
+	# trigger ticket 1767
+	# build a signal fire
+	gui.trigger('tab', 'button_22/action/default')
+	gui.cursor_click(58, 5, 'left')
+	gui.cursor_click(58, 4, 'left')
+
 	yield TestFinished


### PR DESCRIPTION
This was fixed by commit 0cc706dff9c360a96894922467e620b699576050.

Traceback (most recent call last):
  File "/unknown-horizons/tests/gui/ingame/test_build.py", line 123, in test_found_settlement
    gui.cursor_click(58, 5, 'left')
  File "/unknown-horizons/tests/gui/helper.py", line 225, in cursor_click
    self.cursor_move(x, y)
  File "/unknown-horizons/tests/gui/helper.py", line 214, in cursor_move
    self.cursor.mouseMoved(self._make_mouse_event(x, y))
  File "/unknown-horizons/horizons/gui/mousetools/buildingtool.py", line 470, in mouseMoved
    self._check_update_preview(point)
  File "/unknown-horizons/horizons/gui/mousetools/buildingtool.py", line 614, in _check_update_preview
    self.update_preview()
  File "/unknown-horizons/horizons/gui/mousetools/buildingtool.py", line 641, in update_preview
    self.start_point if self.end_point is None else self.end_point, force=force)
  File "/unknown-horizons/horizons/gui/mousetools/buildingtool.py", line 342, in preview_build
    self._draw_preview_building_range(building, settlement)
  File "/unknown-horizons/horizons/gui/mousetools/buildingtool.py", line 376, in _draw_preview_building_range
    self.selectable_comp.select_building(self.session, building.position, settlement, self._class.radius, radius_only_on_island)
  File "/unknown-horizons/horizons/component/selectablecomponent.py", line 201, in select_building
    radius, range_applies_only_on_island)
  File "/unknown-horizons/horizons/component/selectablecomponent.py", line 272, in _do_select
    cls._init_fake_tile()
  File "/unknown-horizons/horizons/component/selectablecomponent.py", line 288, in _init_fake_tile
    cls._fake_tile_obj = horizons.main.fife.engine.getModel().createObject('fake_tile_obj', 'ground')
  File "/usr/lib/python2.7/dist-packages/fife/fife.py", line 9642, in createObject
    return _fife.Model_createObject(self, *args)
RuntimeError: _[NameClash]_ , A name or identifier is already in use :: fake_tile_obj
