### PR TITLE
Fixed test_settler_level_save_load.

### DIFF
--- a/tests/game/test_load_save.py
+++ b/tests/game/test_load_save.py
@@ -247,9 +247,6 @@ def test_settler_level_save_load(s, p):
 		settler = Build(BUILDINGS.RESIDENTIAL, 22, 22, island, settlement=settlement)(p)
 		settler.level += test_level
 		settler_worldid = settler.worldid
-
-		# give it population
-		settler.inhabitants = settler.inhabitants_max
 		
 		# make it happy
 		inv = settler.get_component(StorageComponent).inventory
@@ -272,7 +269,7 @@ def test_settler_level_save_load(s, p):
 		inv.alter(RES.BOARDS, 100)
 		inv.alter(RES.BRICKS, 100)
 		
-		# make sure it still has max population
+		# give it max population
 		settler.inhabitants = settler.inhabitants_max		
 
 		s.run(seconds=GAME.INGAME_TICK_INTERVAL)


### PR DESCRIPTION
It wasn't giving the settler population, which is now required to level up.
I set it to give maximum population twice because the settler was losing population during the first tick.
