### PR TITLE
* New component RestrictedPickup (right now used for SettlerCollector)

### DIFF
--- a/content/game.sql
+++ b/content/game.sql
@@ -103,15 +103,6 @@ INSERT INTO "sounds_special" VALUES('success',  11);
 INSERT INTO "sounds_special" VALUES('refresh',  12);
 INSERT INTO "sounds_special" VALUES('click',    13);
 
-CREATE TABLE "collector_restrictions" (
-	"collector" INT,
-	"object" INT
-);
-INSERT INTO "collector_restrictions" VALUES(1000011,  4);
-INSERT INTO "collector_restrictions" VALUES(1000011,  5);
-INSERT INTO "collector_restrictions" VALUES(1000011, 21);
-INSERT INTO "collector_restrictions" VALUES(1000011, 32);
-
 CREATE TABLE "message" (
 	"id_string" TEXT NOT NULL,
 	"icon" INT NOT NULL,

--- a/content/objects/units/collectors/settlercollector.yaml
+++ b/content/objects/units/collectors/settlercollector.yaml
@@ -8,6 +8,12 @@ components:
 - StorageComponent:
       PositiveSizedSlotStorage:
          limit: 8
+- RestrictedPickup:
+    allowed:
+    - BUILDINGS.MAIN_SQUARE
+    - BUILDINGS.PAVILION
+    - BUILDINGS.VILLAGE_SCHOOL
+    - BUILDINGS.TAVERN
 
 actionsets:
   TIER.SAILORS:

--- a/horizons/component/componentholder.py
+++ b/horizons/component/componentholder.py
@@ -29,6 +29,7 @@ from horizons.component.healthcomponent import HealthComponent
 from horizons.component.selectablecomponent import SelectableComponent
 from horizons.component.commandablecomponent import CommandableComponent
 from horizons.component.collectingcomponent import CollectingComponent
+from horizons.component.restrictedpickup import RestrictedPickup
 from horizons.world.production.producer import Producer, QueueProducer, UnitProducer
 
 class ComponentHolder(object):
@@ -71,6 +72,7 @@ class ComponentHolder(object):
 	    'SelectableComponent': SelectableComponent,
 	    'CommandableComponent': CommandableComponent,
 	    'CollectingComponent': CollectingComponent,
+	    'RestrictedPickup': RestrictedPickup,
 	}
 
 

--- a/horizons/component/restrictedpickup.py
+++ b/horizons/component/restrictedpickup.py
@@ -1,0 +1,37 @@
+# ###################################################
+# Copyright (C) 2012 The Unknown Horizons Team
+# team@unknown-horizons.org
+# This file is part of Unknown Horizons.
+#
+# Unknown Horizons is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# ###################################################
+
+from horizons.component import Component
+
+class RestrictedPickup(Component):
+	""" Handles pickup location restrictions per whitelist.
+	Treats something as allowed (not restricted) if contained
+	in the whitelist *allowed*. If this is specified but empty,
+	everything is considered forbidden.
+	"""
+	NAME = 'restricted'
+
+	def __init__(self, allowed=None):
+		super(RestrictedPickup, self).__init__()
+		self.allowed = allowed or []
+
+	def pickup_allowed_at(self, target_class):
+		return target_class in self.allowed


### PR DESCRIPTION
Treats something as allowed (not restricted) if it is contained in the
whitelist "allowed". If you wish your collector to have no restrictions,
just do not add this component to its object file.

The presence of RestrictedPickup with an empty "allowed" line will
forbid the collector from picking up anything.
