### PR TITLE
Clear selection when entering tearing tool. Fix #1532

### DIFF
--- a/horizons/gui/mousetools/tearingtool.py
+++ b/horizons/gui/mousetools/tearingtool.py
@@ -44,6 +44,7 @@ class TearingTool(NavigationTool):
 		self.tear_tool_active = True
 		self.session.gui.on_escape = self.on_escape
 		self.session.ingame_gui.hide_menu()
+		self.session.selected_instances.clear()
 		horizons.globals.fife.set_cursor_image("tearing")
 		self._hovering_over = WeakList()
 		WorldObjectDeleted.subscribe(self._on_object_deleted)


### PR DESCRIPTION
When not clearing the selection, the selection tool will still assume
the building is selected and therefore not call the SelectableComponent.
## 

Could someone have a look if this is reasonable? I'm not playing often, so I might miss some use case for keeping the selection or something like that.
