### PR TITLE
Build BuildableRect from the first click point to the second, instead of left to right, bottom to top

### DIFF
--- a/horizons/world/building/buildable.py
+++ b/horizons/world/building/buildable.py
@@ -332,17 +332,17 @@ class BuildableRect(Buildable):
 		area.top -= (cls.size[1] - 1) / 2
 		area.bottom -= (cls.size[1] - 1) / 2
 
-                xstart, xend = area.left, area.right+1
-                xstep = cls.size[0]
-                if point1.x > point2.x:
-                        xstart, xend = area.right, area.left-1
-                        xstep *= -1
+		xstart, xend = area.left, area.right+1
+		xstep = cls.size[0]
+		if point1.x > point2.x:
+			xstart, xend = area.right, area.left-1
+			xstep *= -1
 
-                ystart, yend = area.top, area.bottom+1
-                ystep = cls.size[1]
-                if point1.y > point2.y:
-                        ystart, yend = area.bottom, area.top-1
-                        ystep *= -1
+		ystart, yend = area.top, area.bottom+1
+		ystep = cls.size[1]
+		if point1.y > point2.y:
+			ystart, yend = area.bottom, area.top-1
+			ystep *= -1
 
 		for x in xrange(xstart, xend, xstep):
 			for y in xrange(ystart, yend, ystep):


### PR DESCRIPTION
The fill method when building a BuildableRect buillding is to fill from left to
right, from bottom to top, instead of from the first point the user clicked on,
to the current mouse position. This can be annoying for building with size >1
(such as tents), because the buildings won't have constants positions when the
user move the mouse, depending on the direction he is moving (if he is building
from left to right, there's no problem, but from right to left, the building
will move each time the mouse go over a new case)
