### PR TITLE
Minimap rectangle should have cursor centered, regardless of zoom level ...

### DIFF
--- a/horizons/view.py
+++ b/horizons/view.py
@@ -234,8 +234,8 @@ class View(ChangeListener):
 		width_y = horizons.globals.fife.engine_settings.getScreenHeight() // cell_dim.y + 1
 		zoom = self.get_zoom()
 		screen_width_as_coords = (width_x // zoom, width_y // zoom)
-		return Rect.init_from_topleft_and_size(coords.x - (width_x // 2),
-		                                       coords.y - (width_y // 2),
+		return Rect.init_from_topleft_and_size(coords.x - (screen_width_as_coords[0] // 2),
+		                                       coords.y - (screen_width_as_coords[1] // 2),
 		                                       *screen_width_as_coords)
 
 	def save(self, db):


### PR DESCRIPTION
...(#1969)

When the cursor clicks on an area in the minimap, the rectangle should
indicate the displayed area, with the cursor centered inside it. To get
the cursor centered rather than in the upper left corner, we move this
corner by an offset calculated by the width and height of the rectangle.
However, up until now, this offset did not include zoom level which
means the cursor was not centered properly when zooming out.
