### PR TITLE
Hand out a default for Dialog.return_events

### DIFF
--- a/horizons/gui/windows.py
+++ b/horizons/gui/windows.py
@@ -110,7 +110,7 @@ class Dialog(Window):
 
 		self._gui = None
 		self._hidden = False
-		self._return_events = {}
+		self.return_events = {}
 
 	def prepare(self, **kwargs):
 		"""Setup the dialog gui.


### PR DESCRIPTION
Was probably intended this way, PR to make sure @squiddy agrees with the change.
