### PR TITLE
Fix Escape confirming Dialog.

### DIFF
--- a/horizons/gui/windows.py
+++ b/horizons/gui/windows.py
@@ -175,7 +175,7 @@ class Dialog(Window):
 
 		# Convention says use cancel action
 		if event.getKey().getValue() == fife.Key.ESCAPE:
-			self.trigger_close(OkButton.DEFAULT_NAME)
+			self.trigger_close(CancelButton.DEFAULT_NAME)
 		# Convention says use ok action
 		elif event.getKey().getValue() == fife.Key.ENTER:
 			self.trigger_close(OkButton.DEFAULT_NAME)
@@ -195,7 +195,7 @@ class Dialog(Window):
 
 	def _execute(self):
 		"""Execute the dialog synchronously.
-		
+
 		This is done by entering a new mainloop in the engine until the dialog
 		is closed (see `abort`).
 		"""


### PR DESCRIPTION
When I introduced the trigger_close function, a small bug was introduced: pressing Escape confirmed the Dialog, instead of canceling.
