### PR TITLE
Replace `isinstance` checks for specific CursorTools with `hasattr`

### DIFF
--- a/horizons/editor/gui.py
+++ b/horizons/editor/gui.py
@@ -156,7 +156,7 @@ class IngameGui(LivingObject):
 		if action == _Actions.ESCAPE:
 			if self.windows.visible:
 				self.windows.on_escape()
-			elif not isinstance(self.cursor, SelectionTool):
+			elif hasattr(self.cursor, 'on_escape'):
 				self.cursor.on_escape()
 			else:
 				self.toggle_pause()

--- a/horizons/gui/ingamegui.py
+++ b/horizons/gui/ingamegui.py
@@ -340,7 +340,7 @@ class IngameGui(LivingObject):
 	def on_escape(self):
 		if self.windows.visible:
 			self.windows.on_escape()
-		elif not isinstance(self.cursor, mousetools.SelectionTool):
+		elif hasattr(self.cursor, 'on_escape'):
 			self.cursor.on_escape()
 		else:
 			self.toggle_pause()


### PR DESCRIPTION
Perhaps the lesser of two evils here, as suggested by @totycro
Fixes #2051  Pressing Esc in resource overview bar crashes
