### PR TITLE
Auto-detect and set resolution on first run (#1568)

### DIFF
--- a/horizons/engine/engine.py
+++ b/horizons/engine/engine.py
@@ -171,18 +171,18 @@ class Fife(ApplicationBase):
 			# Compare the desktop's resolution with the game's current resolution
 			desktop_width = self.engine.getDeviceCaps().getDesktopWidth()
 			desktop_height = self.engine.getDeviceCaps().getDesktopHeight()
-			closest_width_difference = desktop_width - current_width
-			closest_height_difference = desktop_height - current_height
+			closest_width_difference = abs(desktop_width - current_width)
+			closest_height_difference = abs(desktop_height - current_height)
 			
 			# Compare all available resolutions with the game's current resolution
 			for available_resolution in available_resolutions:
 				(width, height) = available_resolution.split('x')
-				width_difference = desktop_width - int(width)
-				height_difference = desktop_height - int(height)
+				width_difference = abs(desktop_width - int(width))
+				height_difference = abs(desktop_height - int(height))
 				
 				# If another available resolution is closer to the desktop's resolution
-				if ((abs(width_difference) <= closest_width_difference) and
-					(abs(height_difference) <= closest_height_difference)):
+				if (width_difference <= closest_width_difference and
+					height_difference <= closest_height_difference):
 					# Update the closest resolution
 					closest_width = width
 					closest_width_difference = width_difference


### PR DESCRIPTION
**(Do not merge yet.)**
Implements a fix for issue #1568. Automatically sets the game's resolution to that of the desktop the first time the game is run.

Looks for a value corresponding to the 'LatestBackground' setting in order to determine if the game has been run before (as 'LatestBackground' does not have a default value and is set when the game is first run).

Destroys and re-initializes the engine to force the change without restarting.
