### PR TITLE
Fix tooltips being shown twice

### DIFF
--- a/horizons/gui/widgets/tooltip.py
+++ b/horizons/gui/widgets/tooltip.py
@@ -46,6 +46,7 @@ class _Tooltip(object):
 			self.name + '/mouseDragged/tooltip' : self.hide_tooltip
 			})
 		self.tooltip_shown = False
+		self.shown = False
 
 	def __init_gui(self):
 		self.gui = AutoResizeContainer()
@@ -97,6 +98,10 @@ class _Tooltip(object):
 			self.tooltip_shown = True
 
 	def show_tooltip(self):
+		if self.shown is True:
+			return
+		self.shown = True
+
 		if not self.helptext:
 			return
 		if self.gui is None:
@@ -116,6 +121,7 @@ class _Tooltip(object):
 		self.gui.show()
 
 	def hide_tooltip(self, event=None):
+		self.shown = False
 		if self.gui is not None:
 			self.gui.hide()
 		ExtScheduler().rem_call(self, self.show_tooltip)


### PR DESCRIPTION
It seems like the real problem is that the way we handle showing tooltips is flawed. Tooltips are supposed to the hidden by the mouseExited event, but this event doesn't always seem to trigger properly. 
Specifically, it doesn't seem to trigger when you move the cursor horizontally or vertically. Moving it diagonally seems to work fine. Also, a problem appears when moving the mouse out of the game window when a tooltip is shown.
The cleanest way to fix this would be to detect whether the cursor is placed on an icon with a tooltip each time we call position_tooltip(), but I don't know how to do this and it possibly would be too slow.

Still, my solution seems to fix issue #1451 just fine, and it could be merged, should we choose not to change the tooltip detection system for now.
Also, there's another attribute called self.tooltip_show which, I think, had the same purpose as self.shown ( which I just added ), but doesn't seem to work. Should I just delete it?
