### PR TITLE
Reduce LOGBOOK_DEFAULT_DELAY from 4 to 1 second.

### DIFF
--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -363,7 +363,7 @@ class GUI:
 class MESSAGES:
 	CUSTOM_MSG_SHOW_DELAY = 6 # delay between messages when passing more than one
 	CUSTOM_MSG_VISIBLE_FOR = 90 # after this time the msg gets removed from screen
-	LOGBOOK_DEFAULT_DELAY = 4 # delay between condition fulfilled and logbook popping up
+	LOGBOOK_DEFAULT_DELAY = 1 # delay between condition fulfilled and logbook popping up
 
 # AI values read from the command line; use the values below unless overridden by the CLI or the GUI
 class AI:


### PR DESCRIPTION
In my opinion this makes the game feel faster and more alert. Also, this fixes the "bug" when the player waits a potential 7 seconds before receiving feedback on completing a scenario goal. Fixes #1576 
