### PR TITLE
Fix scenario messages being displayed only after Logbook is hidden.

### DIFF
--- a/horizons/gui/widgets/logbook.py
+++ b/horizons/gui/widgets/logbook.py
@@ -136,6 +136,8 @@ class LogBook(PickBeltWidget, Window):
 		if (value and value[0] and value[0][0]):
 			self.set_cur_entry(int(value[0][0])) # this also redraws
 
+		self.display_messages()
+
 	def show(self, msg_id=None):
 		if not hasattr(self, '_gui'):
 			self._init_gui()
@@ -147,6 +149,15 @@ class LogBook(PickBeltWidget, Window):
 			if self.current_mode == self.statistics_index:
 				self.show_statswidget(self.last_stats_widget)
 
+	def display_messages(self):
+		"""Display all messages in self._messages_to_display and map the to the current logbook page"""
+		for message in self._messages_to_display:
+			if message in self._displayed_messages:
+				continue
+			for msg_id in show_message(self.session, "logbook", message):
+				self._page_ids[msg_id] = self._cur_entry
+				self._displayed_messages.append(message)
+
 	def hide(self):
 		if not self._hiding_widget:
 			self._hiding_widget = True
@@ -154,14 +165,7 @@ class LogBook(PickBeltWidget, Window):
 			self._gui.hide()
 			self._hiding_widget = False
 
-			for message in self._messages_to_display:
-				# show all messages (except those already displayed) and map them to the current logbook page
-				if message in self._displayed_messages:
-					continue
-				for msg_id in show_message(self.session, "logbook", message):
-					self._page_ids[msg_id] = self._cur_entry
-					self._displayed_messages.append(message)
-
+			self.display_messages()
 			self._message_log.extend(self._messages_to_display)
 			self._messages_to_display = []
 		# Make sure the game is unpaused always and in any case


### PR DESCRIPTION
Scenario messages are now stored into logbook._messages_to_display, and are only displayed on logbook.hide(). This usually works because when scenario messages are received, the logbook is shown, and to see the messages, you need to hide the logbook.
The problem is that when loading the game, scenario messages are only shown after showing and hiding the logbook. To fix this, I put the code used for showing messages into a function and called this function when the logbook is loaded.
Fixes #1790 
