### PR TITLE
Check message log before posting message

### DIFF
--- a/horizons/gui/widgets/logbook.py
+++ b/horizons/gui/widgets/logbook.py
@@ -225,7 +225,10 @@ class LogBook(PickBeltWidget, Window):
 			# duplicate_message stops messages from
 			# being duplicated on page reload.
 			message = parameter[1]
-			duplicate_message = message in self._messages_to_display # message is already going to be displayed
+			# message is already going to be displayed or has been displayed
+			# before (e.g. re-opening older logbook pages)
+			duplicate_message = (message in self._messages_to_display or  
+								message in self._message_log)
 
 			if not duplicate_message:
 				self._messages_to_display.append(message) # the new message has not been displayed


### PR DESCRIPTION
Fixes #2111 "Closing the logbook creates a notification message for
finished objectives." _message_log contains previously displayed
messages so check that list before displaying.

Update to comments to match style per feedback from pull request.

This is a re-request for #2114 because I couldn't figure out how to push my rebased commits without deleting the remote branch. Sorry for the confusion.
