### PR TITLE
Remove package and module __all__ definitions

### DIFF
--- a/horizons/__init__.py
+++ b/horizons/__init__.py
@@ -18,5 +18,3 @@
 # Free Software Foundation, Inc.,
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
-
-__all__ = ['dbreader', 'engine', 'main', 'manager', 'scheduler', 'session', 'settings', 'timer', 'view', 'network', 'world']

--- a/horizons/command/__init__.py
+++ b/horizons/command/__init__.py
@@ -19,13 +19,12 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-__all__ = ['building', 'unit', 'sounds']
-
 import logging
 
 from horizons.util.python import get_all_subclasses
 from horizons.util.worldobject import WorldObject
 from horizons.network.packets import SafeUnpickler
+
 
 class Command(object):
 	"""Base class for every Command."""

--- a/horizons/network/common.py
+++ b/horizons/network/common.py
@@ -24,12 +24,6 @@ from gettext import NullTranslations
 
 from horizons.network import packets, enet
 
-__all__ = [
-  'Address',
-  'Player',
-  'Game',
-  'ErrorType',
-]
 
 class Address(object):
 	def __init__(self, address, port=None):

--- a/horizons/network/packets/__init__.py
+++ b/horizons/network/packets/__init__.py
@@ -31,10 +31,6 @@ except ImportError:
 from horizons.network import NetworkException, PacketTooLarge
 
 __version__ = '0.1'
-__all__ = [
-	'SafeUnpickler',
-	'packet',
-]
 
 PICKLE_PROTOCOL = 2
 PICKLE_RECIEVE_FROM = 'server'

--- a/horizons/util/pathfinding/__init__.py
+++ b/horizons/util/pathfinding/__init__.py
@@ -19,9 +19,7 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-__all__ = ['pathnodes', 'pather', 'pathfinding']
 
 class PathBlockedError(Exception):
 	"""Exception to be thrown when a path is unexpectedly blocked"""
 	pass
-

--- a/horizons/world/__init__.py
+++ b/horizons/world/__init__.py
@@ -20,8 +20,6 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-__all__ = ['island', 'nature', 'player', 'settlement', 'ambientsound']
-
 import logging
 import json
 import copy
@@ -55,6 +53,7 @@ from horizons.world.disaster.disastermanager import DisasterManager
 from horizons.world import worldutils
 from horizons.util.savegameaccessor import SavegameAccessor
 from horizons.messaging import LoadingProgress
+
 
 class World(BuildingOwner, WorldObject):
 	"""The World class represents an Unknown Horizons map with all its units, grounds, buildings, etc.

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -20,16 +20,15 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-__all__ = ['building', 'housing', 'nature', 'path', 'production', 'storages', 'settler', 'boatbuilder']
-
 import logging
 
-import horizons.globals
 from fife import fife
 
+import horizons.globals
 from horizons.util.loaders.actionsetloader import ActionSetLoader
 from horizons.world.ingametype import IngameType
 from horizons.world.production.producer import Producer
+
 
 class BuildingClass(IngameType):
 	log = logging.getLogger('world.building')

--- a/horizons/world/production/__init__.py
+++ b/horizons/world/production/__init__.py
@@ -19,6 +19,3 @@
 # Free Software Foundation, Inc.,
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
-
-__all__ = ['production', 'producer', 'productionline', 'unitproduction']
-

--- a/horizons/world/units/__init__.py
+++ b/horizons/world/units/__init__.py
@@ -19,8 +19,6 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-__all__ = ['animal', 'nature', 'ship', 'unit']
-
 import logging
 
 from fife import fife
@@ -29,6 +27,7 @@ import horizons.globals
 from horizons.util.loaders.actionsetloader import ActionSetLoader
 from horizons.util.python.callback import Callback
 from horizons.world.ingametype import IngameType
+
 
 class UnitClass(IngameType):
 

--- a/horizons/world/units/collectors/__init__.py
+++ b/horizons/world/units/collectors/__init__.py
@@ -19,8 +19,6 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-__all__ = ['collector', 'buildingcollector', 'animalcollector']
-
 from buildingcollector import BuildingCollector, FieldCollector, StorageCollector, FisherShipCollector, DisasterRecoveryCollector, SettlerCollector
 from animalcollector import AnimalCollector, HunterCollector, FarmAnimalCollector
 from collector import Collector, Job, JobList

--- a/run_uh.py
+++ b/run_uh.py
@@ -30,8 +30,6 @@ This is the Unknown Horizons launcher; it looks for FIFE and tries
 to start the game. You usually don't need to work with this directly.
 If you want to dig into the game, continue to horizons/main.py. """
 
-__all__ = ['init_environment']
-
 import sys
 import os
 import os.path


### PR DESCRIPTION
We do not use star imports anywhere (exception: messaging.message), and most of it was either outdated or very questionable anyways.
