### PR TITLE
Added confirm option for deletion; patch for #2153

### DIFF
--- a/horizons/gui/ingamegui.py
+++ b/horizons/gui/ingamegui.py
@@ -473,7 +473,7 @@ class IngameGui(LivingObject):
 			self.toggle_destroy_tool()
 		elif action == _Actions.REMOVE_SELECTED:
 			message = _(u"Are you sure you want to delete these objects?")
-			if self.windows.show_popup(u"Delete", message, show_cancel_button=True):
+			if self.windows.show_popup(_(u"Delete"), message, show_cancel_button=True):
 				self.session.remove_selected()
 			else:
 				self.deselect_all()


### PR DESCRIPTION
Hello!

This is my first attempt at #2153.

I've added a small confirmation of removal message that appears whenever the player presses the delete key having an object selected, and disappears after a very short interval. If the player presses Y after the delete key is pressed, the removal shall be executed, or in case he presses N, the removal shall be aborted.

Please tell me what you think about this, thank you!
