### PR TITLE
updated preview

### DIFF
--- a/horizons/gui/mousetools/tilelayingtool.py
+++ b/horizons/gui/mousetools/tilelayingtool.py
@@ -105,6 +105,7 @@ class TileLayingTool(NavigationTool):
 		if evt.getButton() == fife.MouseEvent.LEFT:
 			coords = self.get_world_location(evt).to_tuple()
 			self._place_tile(coords)
+			self.update_coloring(evt)
 			evt.consume()
 
 	def update_coloring(self, evt):


### PR DESCRIPTION
Hello!

This is a very small patch I made for #2016 . When the mouse was being dragged while laying tiles in the editor, the preview remained stuck where the dragging began. This fixes the problem, now the preview follows the cursor while dragging.

Hope it works alright! Please tell me if there is any trouble! 
