### PR TITLE
make pause & resume work correctly (bug #2211)

### DIFF
--- a/horizons/editor/gui.py
+++ b/horizons/editor/gui.py
@@ -87,7 +87,7 @@ class IngameGui(LivingObject):
 		self.windows = WindowManager()
 		self.message_widget = MessageWidget(self.session)
 		self.pausemenu = PauseMenu(self.session, self, self.windows, in_editor_mode=True)
-		self.help_dialog = HelpDialog(self.windows, session=self.session)
+		self.help_dialog = HelpDialog(self.windows)
 
 	def end(self):
 		self.mainhud.mapEvents({

--- a/horizons/gui/ingamegui.py
+++ b/horizons/gui/ingamegui.py
@@ -90,7 +90,7 @@ class IngameGui(LivingObject):
 		self.chat_dialog = ChatDialog(self.windows, self.session)
 		self.change_name_dialog = ChangeNameDialog(self.windows, self.session)
 		self.pausemenu = PauseMenu(self.session, self, self.windows, in_editor_mode=False)
-		self.help_dialog = HelpDialog(self.windows, session=self.session)
+		self.help_dialog = HelpDialog(self.windows)
 
 		# Icon manager
 		self.status_icon_manager = StatusIconManager(

--- a/horizons/gui/modules/help.py
+++ b/horizons/gui/modules/help.py
@@ -21,7 +21,6 @@
 
 from fife.extensions.pychan.widgets import Label
 
-from horizons.command.game import PauseCommand, UnPauseCommand
 from horizons.gui.modules.loadingscreen import GAMEPLAY_TIPS
 from horizons.gui.util import load_uh_widget
 from horizons.gui.widgets.imagebutton import OkButton
@@ -30,10 +29,9 @@ from horizons.gui.windows import Window
 
 class HelpDialog(Window):
 
-	def __init__(self, windows, session=None):
+	def __init__(self, windows):
 		super(HelpDialog, self).__init__(windows)
 
-		self._session = session
 		self.widget = load_uh_widget('help.xml')
 		self.widget.findChild(name=OkButton.DEFAULT_NAME).capture(self._windows.close)
 		self.widget.findChild(name='headline').text = GAMEPLAY_TIPS['name']
@@ -45,10 +43,6 @@ class HelpDialog(Window):
 
 	def show(self):
 		self.widget.show()
-		if self._session:
-			PauseCommand().execute(self._session)
 
 	def hide(self):
-		if self._session:
-			UnPauseCommand().execute(self._session)
 		self.widget.hide()

--- a/horizons/gui/modules/pausemenu.py
+++ b/horizons/gui/modules/pausemenu.py
@@ -70,12 +70,18 @@ class PauseMenu(Window):
 			'quit'    : events['quit'],
 		})
 
-	def show(self):
+	def open(self):
+		super(PauseMenu, self).open()
 		PauseCommand(suggestion=True).execute(self._session)
+
+	def show(self):
 		self._gui.show()
 
 	def hide(self):
 		self._gui.hide()
+
+	def close(self):
+		super(PauseMenu, self).close()
 		UnPauseCommand(suggestion=True).execute(self._session)
 
 	def _do_quit(self):

--- a/horizons/gui/windows.py
+++ b/horizons/gui/windows.py
@@ -40,6 +40,11 @@ class Window(object):
 
 		self._modal_background = None
 
+	def open(self, **kwargs):
+		"""Opens the window.
+		"""
+		self.show()
+
 	def show(self, **kwargs):
 		"""Show the window.
 
@@ -287,7 +292,7 @@ class WindowManager(object):
 	def __init__(self):
 		self._windows = []
 
-	def show(self, window, **kwargs):
+	def show(self, window, _open=False, **kwargs):
 		"""Show a new window on top.
 
 		Hide the current one and show the new one.
@@ -297,7 +302,10 @@ class WindowManager(object):
 			self._windows[-1].hide()
 
 		self._windows.append(window)
-		return window.show(**kwargs)
+		if _open:
+			return window.open(**kwargs)
+		else:
+			return window.show(**kwargs)
 
 	def close(self):
 		"""Close the top window.
@@ -314,9 +322,11 @@ class WindowManager(object):
 		if self._windows and self._windows[-1] == window:
 			self.close()
 		else:
+			_open = True
 			if window in self._windows:
 				self._windows.remove(window)
-			self.show(window, **kwargs)
+				_open = False
+			self.show(window, _open=_open, **kwargs)
 
 	def on_escape(self):
 		"""Let the topmost window handle an escape key event."""


### PR DESCRIPTION
This resolves bug #2211 (Game resumes after entering dialogs spawned by game menu)
When `WindowManager._session` is not None, the game is paused when any window is opened.
When `WindowManager._session` is None, nothing happens.

=> I suggest to make WindowManager responsible for Pause and UnPause
