### PR TITLE
Fix cursor in editor [NEED TO BE FIXED]

### DIFF
--- a/horizons/editor/gui.py
+++ b/horizons/editor/gui.py
@@ -205,6 +205,8 @@ class SettingsTab(TabInterface):
 		super(SettingsTab, self).__init__(widget=self.widget)
 
 		self._world_editor = world_editor
+		self.current_tile = 'sand'
+		self.ingame_gui = ingame_gui
 
 		# Brush size
 		for i in range(1, 6):
@@ -220,7 +222,27 @@ class SettingsTab(TabInterface):
 			tile = getattr(GROUND, tile_type.upper())
 			image.up_image = self._get_tile_image(tile)
 			image.size = image.min_size = image.max_size = (64, 32)
-			image.capture(Callback(ingame_gui.set_cursor, 'tile_layer', tile))
+			image.capture(Callback(self.set_cursor_tile, tile))
+
+		self.widget.mapEvents({
+				self.widget.name+'/mouseEntered/cursor' : self.cursor_inside,
+				self.widget.name+'/mouseExited/cursor' : self.cursor_outside,
+				})
+
+                self.ingame_gui.mainhud.mapEvents({
+				self.ingame_gui.mainhud.name+'/mouseEntered/cursor' : self.cursor_inside,
+				self.ingame_gui.mainhud.name+'/mouseExited/cursor' : self.cursor_outside,
+				})
+
+	def set_cursor_tile(self, tile):
+		self.current_tile = tile
+		self.ingame_gui.set_cursor('tile_layer', self.current_tile)
+
+	def cursor_inside(self):
+		horizons.globals.fife.set_cursor_image('default')
+
+	def cursor_outside(self):
+		self.ingame_gui.set_cursor('tile_layer', self.current_tile)
 
 	def _get_tile_image(self, tile):
 		# TODO TileLayingTool does almost the same thing, perhaps put this in a better place


### PR DESCRIPTION
I noticed that when editing a map and the cursor is set to a tile, it doesn't change back to an arrow when hovering over the GUI. I made it do that.
There's a small problem in the way I implemented it: you must always have a tile selected, which means that right click doesn't change back to arrow cursor anymore. I don't know how to fix this, since I can't find an event for right click. Please let me know what you want me to do about this.