### PR TITLE
Fixes #2267 and restores layout of production line tabs with multiple re...

### DIFF
--- a/content/gui/xml/ingame/templates/overview_farmproductionline.xml
+++ b/content/gui/xml/ingame/templates/overview_farmproductionline.xml
@@ -15,15 +15,15 @@
 		<Icon image="content/gui/icons/templates/production/production_arrow_head.png" position="107,17" />
 		<VBox name="output_box" position="136,17" />
 
-	<!-- one of those button gets removed at runtime -->
-	<ImageButton path="icons/templates/production/toggle_small_active"
-		position="82,-2" name="toggle_active_active" helptext="Pause production" />
+		<!-- one of those button gets removed at runtime -->
+		<ImageButton path="icons/templates/production/toggle_small_active"
+			position="82,-2" name="toggle_active_active" helptext="Pause production" />
 
-	<ImageButton path="icons/templates/production/toggle_small_inactive"
-		position="82,-2" name="toggle_active_inactive" helptext="Start production" />
+		<ImageButton path="icons/templates/production/toggle_small_inactive"
+			position="82,-2" name="toggle_active_inactive" helptext="Start production" />
 
-	<VBox name="output_res" position="157,0" />
-</Container>
+		<VBox name="output_res" position="157,0" />
+	</Container>
 
 	<VBox name="input_box" position="61,17" />
 

--- a/content/gui/xml/ingame/templates/overview_productionline.xml
+++ b/content/gui/xml/ingame/templates/overview_productionline.xml
@@ -9,10 +9,9 @@
 	If there are n res in one column, the container will have the size n * height.
 -->
 <AutoResizeContainer position="25,110" name="production_line_container">
+	<VBox name="input_res" position="2,0" />
+	
 	<Container name="centered_production_icons" size="200,55">
-		<VBox name="input_res" position="2,0" />
-
-		<VBox name="input_box" position="61,16" />
 		<Icon image="content/gui/icons/templates/production/production_arrow_head.png" position="107,17" />
 		<VBox name="output_box" position="136,17" />
 
@@ -26,4 +25,5 @@
 		<VBox name="output_res" position="158,4" />
 	</Container>
 
+	<VBox name="input_box" position="61,16" />
 </AutoResizeContainer>

--- a/horizons/gui/tabs/productiontabs.py
+++ b/horizons/gui/tabs/productiontabs.py
@@ -112,9 +112,9 @@ class ProductionOverviewTab(OverviewTab):
 					self._animations.append( weakref.ref( anim ) )
 
 			# fill it with input and output resources
-			in_res_container = centered_container.findChild(name="input_res")
+			in_res_container = container.findChild(name="input_res")
 			self._add_resource_icons(in_res_container, production.get_consumed_resources(), marker=True)
-			out_res_container = centered_container.findChild(name="output_res")
+			out_res_container = container.findChild(name="output_res")
 			self._add_resource_icons(out_res_container, production.get_produced_resources())
 
 			# active toggle_active button


### PR DESCRIPTION
This resolves the `horizons/gui/tabs/productiontabs.py` issues that was addressed in 97d3e5ababfced27370e7c07ebe9dc1dff39bdff where `in_res_container` and `out_res_container` were not searching for `input_res` and `output_res` in the same place which allowed one to succeed and the other to fail. They both need to search in container rather than centered_container due to the structure of the layout.
