### PR TITLE
added ability to lay some resources for testing (WIP); fix for #2199 [NEED TO BE FIXED]

### DIFF
--- a/content/gui/xml/editor/editor_settings.xml
+++ b/content/gui/xml/editor/editor_settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<Container size="250,350" name="editor_settings">
-	<TabBG amount="4" />
+<Container size="250,400" name="editor_settings">
+	<TabBG amount="6" />
 
 	<Container position="0, 20" size="250, 350" max_size="250, 350">
 		<Label text="Select brush size:" name="headline_brush_size" position="25,55" />
@@ -23,6 +23,8 @@
 		<ImageButton position="80,0" name="sand" />
 		<ImageButton position="0,40" name="shallow_water" />
 		<ImageButton position="80,40" name="water" />
+		<Label text="Fish deposit" position="0,80" name="fish_deposit" />
+		<Label text="Tree" position="80,80" name="tree" />
 	</AutoResizeContainer>
-	<Label text="(right click to stop)" name="cursor_hint" position="25,255" />
+	<Label text="(right click to stop)" name="cursor_hint" position="25,280" />
 </Container>

--- a/horizons/command/building.py
+++ b/horizons/command/building.py
@@ -97,7 +97,7 @@ class Build(Command):
 			self.log.debug("Build aborted. Seems like circumstances changed during EXECUTIONDELAY.")
 			# TODO: maybe show message to user
 			return
-
+			
 		# collect data before objs are torn
 		# required by e.g. the mines to find out about the status of the resource deposit
 		if hasattr(Entities.buildings[self.building_class], "get_prebuild_data"):

--- a/horizons/editor/gui.py
+++ b/horizons/editor/gui.py
@@ -227,7 +227,7 @@ class SettingsTab(TabInterface):
 		for building_type in ('fish_deposit', 'tree'):
 			image = self.widget.findChild(name=building_type)
 			building = Entities.buildings[getattr(BUILDINGS, building_type.upper())]
-			image.capture(Callback(ingame_gui.set_cursor,'resource_tool',building))
+			image.capture(Callback(ingame_gui.set_cursor, 'resource_tool', building, building_type))
 
 	def _get_tile_image(self, tile):
 		# TODO TileLayingTool does almost the same thing, perhaps put this in a better place

--- a/horizons/editor/gui.py
+++ b/horizons/editor/gui.py
@@ -21,11 +21,11 @@
 
 import horizons.globals
 
-from horizons.constants import EDITOR, GROUND, VIEW
+from horizons.constants import EDITOR, GROUND, VIEW, BUILDINGS
 from horizons.ext.dummy import Dummy
 from horizons.gui.keylisteners import IngameKeyListener, KeyConfig
 from horizons.gui.modules import PauseMenu, HelpDialog, SelectSavegameDialog
-from horizons.gui.mousetools import SelectionTool, TileLayingTool
+from horizons.gui.mousetools import SelectionTool, TileLayingTool, ResourceTool
 from horizons.gui.tabs import TabWidget
 from horizons.gui.tabs.tabinterface import TabInterface
 from horizons.gui.util import load_uh_widget
@@ -37,6 +37,7 @@ from horizons.util.lastactiveplayersettlementmanager import LastActivePlayerSett
 from horizons.util.living import LivingObject, livingProperty
 from horizons.util.loaders.tilesetloader import TileSetLoader
 from horizons.util.python.callback import Callback
+from horizons.entities import Entities
 
 
 class IngameGui(LivingObject):
@@ -180,7 +181,8 @@ class IngameGui(LivingObject):
 		self.cursor.remove()
 		klass = {
 			'default': SelectionTool,
-			'tile_layer': TileLayingTool
+			'tile_layer': TileLayingTool,
+			'resource_tool': ResourceTool
 		}[which]
 		self.cursor = klass(self.session, *args, **kwargs)
 
@@ -221,6 +223,11 @@ class SettingsTab(TabInterface):
 			image.up_image = self._get_tile_image(tile)
 			image.size = image.min_size = image.max_size = (64, 32)
 			image.capture(Callback(ingame_gui.set_cursor, 'tile_layer', tile))
+
+		for building_type in ('fish_deposit', 'tree'):
+			image = self.widget.findChild(name=building_type)
+			building = Entities.buildings[getattr(BUILDINGS, building_type.upper())]
+			image.capture(Callback(ingame_gui.set_cursor,'resource_tool',building))
 
 	def _get_tile_image(self, tile):
 		# TODO TileLayingTool does almost the same thing, perhaps put this in a better place

--- a/horizons/editor/intermediatemap.py
+++ b/horizons/editor/intermediatemap.py
@@ -125,6 +125,9 @@ class IntermediateMap(object):
 		if coords_list:
 			self._set_tiles(coords_list, new_type)
 
+	def set_building(self, raw_coords, building):
+		self.session.world_editor.set_building(raw_coords,building)
+
 	def _get_surrounding_coords(self, current_coords_list):
 		all_neighbors = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
 		current_coords_set = set(current_coords_list)

--- a/horizons/editor/worldeditor.py
+++ b/horizons/editor/worldeditor.py
@@ -27,13 +27,16 @@ import logging
 from collections import deque
 
 from horizons.command.unit import RemoveUnit
-from horizons.constants import EDITOR
+from horizons.constants import EDITOR, BUILDINGS
 from horizons.editor.intermediatemap import IntermediateMap
 from horizons.entities import Entities
 from horizons.gui.widgets.minimap import Minimap
 from horizons.scheduler import Scheduler
 from horizons.util.dbreader import DbReader
 from horizons.util.python.callback import Callback
+from horizons.command.building import Build
+from horizons.util.shapes import Circle, Point
+# from horizons.entities import Entities
 
 class WorldEditor(object):
 	def __init__(self, world):
@@ -141,6 +144,14 @@ class WorldEditor(object):
 		else:
 			self.world.full_map[coords] = self.world.fake_tile_map[coords]
 		Minimap.update(coords)
+
+		# update cam, that's necessary because of the static layer WATER
+		self.session.view.cam.refresh()
+
+
+	def set_building(self, coords, building_id):
+		Build(building_id, coords[0], coords[1], self.world,45,
+						      ownerless=True)(issuer=None)
 
 		# update cam, that's necessary because of the static layer WATER
 		self.session.view.cam.refresh()

--- a/horizons/engine/engine.py
+++ b/horizons/engine/engine.py
@@ -164,6 +164,8 @@ class Fife(object):
 			'attacking': 'content/gui/images/cursors/cursor_attack.png',
 			'pipette':   'content/gui/images/cursors/cursor_pipette.png',
 			'rename':    'content/gui/images/cursors/cursor_rename.png',
+			'tree':		'content/gfx/terrain/trees/as_maple0/idle_full/45/0.png',
+			'fish_deposit': 'content/gfx/terrain/resources/as_fish0/idle/45/000.png'
 		}
 		self.cursor_images = dict( (k, self.imagemanager.load(v)) for k, v in  cursor_images.iteritems() )
 		self.cursor.set(self.cursor_images['default'])

--- a/horizons/gui/mousetools/__init__.py
+++ b/horizons/gui/mousetools/__init__.py
@@ -29,3 +29,4 @@ from pipettetool import PipetteTool
 
 # Editor tools
 from tilelayingtool import TileLayingTool
+from resourcetool import ResourceTool

--- a/horizons/gui/mousetools/resourcetool.py
+++ b/horizons/gui/mousetools/resourcetool.py
@@ -1,0 +1,44 @@
+from navigationtool import NavigationTool
+from fife import fife
+
+class ResourceTool(NavigationTool):
+	def __init__(self, session, building):
+		super(ResourceTool, self).__init__(session)
+		self.renderer = session.view.renderer['InstanceRenderer']
+		self._building = building
+			
+	def remove(self):
+		super(ResourceTool, self).remove()
+
+	def on_escape(self):
+		self.session.ingame_gui.set_cursor()
+
+	def _place_building(self, coords):
+		self.session.world_editor.intermediate_map.set_building(coords, self._building)
+
+	def get_world_location(self, evt):
+		screenpoint = self._get_screenpoint(evt)
+		mapcoords = self.session.view.cam.toMapCoordinates(screenpoint, False)
+		return self._round_map_coords(mapcoords.x + 0.5, mapcoords.y + 0.5)
+
+	def mousePressed(self, evt):
+		if evt.getButton() == fife.MouseEvent.LEFT:
+			coords = self.get_world_location(evt).to_tuple()
+			self._place_building(coords)
+			evt.consume()
+		elif evt.getButton() == fife.MouseEvent.RIGHT:
+			self.on_escape()
+			evt.consume()
+		else:
+			super(ResourceTool, self).mouseClicked(evt)
+
+	def mouseDragged(self, evt):
+		"""Allow placing tiles continusly while moving the mouse."""
+		if evt.getButton() == fife.MouseEvent.LEFT:
+			coords = self.get_world_location(evt).to_tuple()
+			self._place_building(coords)
+			# self.update_coloring(evt)
+			evt.consume()
+
+	
+	

--- a/horizons/gui/mousetools/resourcetool.py
+++ b/horizons/gui/mousetools/resourcetool.py
@@ -1,18 +1,21 @@
 from navigationtool import NavigationTool
 from fife import fife
+import horizons.globals
 
 class ResourceTool(NavigationTool):
-	def __init__(self, session, building):
+	def __init__(self, session, building, resource_image):
 		super(ResourceTool, self).__init__(session)
 		self.renderer = session.view.renderer['InstanceRenderer']
 		self._building = building
+		horizons.globals.fife.set_cursor_image(resource_image)
 			
 	def remove(self):
 		super(ResourceTool, self).remove()
 
 	def on_escape(self):
+		horizons.globals.fife.set_cursor_image('default')
 		self.session.ingame_gui.set_cursor()
-
+		
 	def _place_building(self, coords):
 		self.session.world_editor.intermediate_map.set_building(coords, self._building)
 


### PR DESCRIPTION
This pull request attempts to fix https://github.com/unknown-horizons/unknown-horizons/issues/2199 .

What I did was add a new tool called ResourceTool, that acts very similarly to the TilelayingTool, only that it should work on buildings instead of tiles. I added two new labels to the gui in the editor, called 'fish_deposit' and 'tree', that when clicked, trigger the ResourceTool similarly to the way the tiles trigger the TilelayingTool.
I also added some necessary functions in intermediatemap.py and in the worldeditor.py to implement the functionality. Momentarily one can add fish deposits  by selecting the fish_deposit label (by clicking and dragging)

This is WIP. I have encountered some issues, and I would really appreciate some feedback/hints from people more knowledgeable than me:

1) I couldn't follow the same procedure to change the cursor image as with the tiles, when selecting the corresponding resource. I got a few fife errors. What images should I add for the cursor, and in what way? I think I saw that the tile images could be found procedurally, the images for the resources at this point could be hardcoded, but I'm pretty sure that is not the way to do it.

2) I was able to lay fish_deposits, but trees are proving to be a bit more problematique. In the Build constructor, when trying to build trees I get a `build_position.buildable == False` no matter what terrain I am laying it on (line 97 in building.py). Could anyone give me a hint on a workaround, please?

3) I need a way to validate the possibility of setting the resource on the map. Due to 2), I'm not sure that checking the tile in the full_map[coords] is enough to tell if that is possible.

I am open to any other remarks on the subject, feedback, hints, suggestions or other possible problems.

Thanks!