### PR TITLE
Better AI names

### DIFF
--- a/content/names.sql
+++ b/content/names.sql
@@ -291,3 +291,17 @@ INSERT INTO "shipnames" VALUES('Swift',1,0,0,1,'en');
 INSERT INTO "shipnames" VALUES('Tower',1,0,0,1,'en');
 INSERT INTO "shipnames" VALUES('Wave',1,0,0,1,'en');
 INSERT INTO "shipnames" VALUES('William',1,0,1,1,'en');
+
+CREATE TABLE "ainames" (
+	"name" TEXT NOT NULL,
+	"locale" TEXT
+);
+INSERT INTO "ainames" VALUES("Christopher Columbus", NULL);
+INSERT INTO "ainames" VALUES("William Adams", NULL);
+INSERT INTO "ainames" VALUES("Vitus Bering", NULL);
+INSERT INTO "ainames" VALUES("John Smith", NULL);
+INSERT INTO "ainames" VALUES("Paulo da Gama", NULL);
+INSERT INTO "ainames" VALUES("Ferdinand Magellan", NULL);
+INSERT INTO "ainames" VALUES("Anna Shchetinina", NULL);
+INSERT INTO "ainames" VALUES("John M. Whitall", NULL);
+INSERT INTO "ainames" VALUES("Leif Eriksson", NULL);

--- a/horizons/util/startgameoptions.py
+++ b/horizons/util/startgameoptions.py
@@ -20,12 +20,27 @@
 # ###################################################
 
 from operator import itemgetter
+from random import shuffle
 
 from horizons.constants import AI, COLORS
 from horizons.util.color import Color
 from horizons.util.difficultysettings import DifficultySettings
 
 class StartGameOptions(object):
+
+	# list of possible ai names. Should somewhen be outsourced to the name database
+	preset_ai_names = [
+		"Christopher Columbus",
+		"William Adams",
+		"Vitus Bering",
+		"John Smith",
+		"Paulo da Gama",
+		"Ferdinand Magellan",
+		"Anna Shchetinina",
+		"John M. Whitall",
+		"Leif Eriksson"
+	]
+
 	def __init__(self, game_identifier):
 		super(StartGameOptions, self).__init__()
 		self.game_identifier = game_identifier
@@ -48,6 +63,11 @@ class StartGameOptions(object):
 		# this is used by the map editor to pass along the new map's size
 		self.map_padding = None
 		self.is_editor = False
+		
+		# copy name list template
+		self.ai_names = self.preset_ai_names[:]
+		# initially shuffle the ai player names so that every game is different
+		shuffle(self.ai_names)
 
 	def init_new_world(self, session):
 		# NOTE: this must be sorted before iteration, cause there is no defined order for
@@ -61,6 +81,17 @@ class StartGameOptions(object):
 	def set_human_data(self, player_name, player_color):
 		self.player_name = player_name
 		self.player_color = player_color
+
+
+	def _generate_ai_name(self, aiNumber):
+		"""Generates a name for the ai player with the given number.
+		
+		The number of the first ai player is 0.
+		"""
+		if aiNumber >= len(self.ai_names):
+			return 'AI' + str(aiNumber + 1)
+		return self.ai_names[aiNumber]
+		
 
 	def _get_player_list(self):
 		if self._player_list is not None:
@@ -89,10 +120,10 @@ class StartGameOptions(object):
 				if not used:
 					color = possible_color
 					break
-
+			
 			players.append({
 				'id' : num + 2,
-				'name' : 'AI' + str(num + 1),
+				'name' : self._generate_ai_name(num),
 				'color' : color,
 				'local' : False,
 				'ai' : True,

--- a/horizons/util/uhdbaccessor.py
+++ b/horizons/util/uhdbaccessor.py
@@ -224,6 +224,20 @@ class UhDbAccessor(DbReader):
 		sql = "SELECT size FROM storage_building_capacity WHERE type = ?"
 		return self.cached_query(sql, storage_type)[0][0]
 
+	def get_random_ai_name(self, locale, used_names):
+		"""Returns a random name compatible with the given locale. If there are
+		no unused names left, None is returned.
+		"""
+		used_names_placeholder = ', '.join(['?']*len(used_names))
+		sql = "SELECT name FROM ainames \
+				WHERE name NOT IN ({0}) AND \
+					  (locale IS NULL OR locale = ?) \
+				ORDER BY random() \
+				LIMIT 1".format(used_names_placeholder)
+		params = used_names
+		params.append(locale)
+		return self(sql, *params)[0][0]
+
 	# Tile sets
 
 	def get_random_tile_set(self, ground_id):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -89,6 +89,10 @@ class ReRunInfoPlugin(Plugin):
 		pass
 
 	def formatError(self, test, err):
+		import nose.case
+		if not isinstance(test, nose.case.Test):
+			return err
+
 		_, module, call = test.address()
 
 		output = ['python2', 'run_tests.py', u'%s:%s' % (module, call)]


### PR DESCRIPTION
Citing @Teemperor in its PR #2351:
> Numbers as AI names are boring, so I've added a small list of explorers/captains that is used as a
> template. if we run out of names, we fall back to the old behaviour.

This includes the changes to PR #2351, that @stubb expected to be made.