### PR TITLE
Allow different collector unit graphics per tier

### DIFF
--- a/horizons/world/building/building.py
+++ b/horizons/world/building/building.py
@@ -24,6 +24,7 @@ import logging
 from fife import fife
 
 from horizons.command.building import Build
+from horizons.component.collectingcomponent import CollectingComponent
 from horizons.component.storagecomponent import StorageComponent
 from horizons.component.componentholder import ComponentHolder
 from horizons.constants import RES, LAYERS, GAME
@@ -203,6 +204,12 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 		"""Upgrades building to another tier"""
 		self.level = lvl
 		self.update_action_set_level(lvl)
+
+		# any collectors (units) should also be upgraded, so that their
+		# graphics or properties can change
+		if self.has_component(CollectingComponent):
+			for collector in self.get_component(CollectingComponent).get_local_collectors():
+				collector.level_upgrade(lvl)
 
 	@classmethod
 	def get_initial_level(cls, player):

--- a/horizons/world/building/settler.py
+++ b/horizons/world/building/settler.py
@@ -34,6 +34,7 @@ from horizons.command.building import Build
 from horizons.util.python.callback import Callback
 from horizons.util.pathfinding.pather import StaticPather
 from horizons.command.production import ToggleActive
+from horizons.component.collectingcomponent import CollectingComponent
 from horizons.component.storagecomponent import StorageComponent
 from horizons.world.status import SettlerUnhappyStatus, SettlerNotConnectedStatus
 from horizons.world.production.producer import Producer
@@ -313,6 +314,11 @@ class Settler(BuildableRect, BuildingResourceHandler, BasicBuilding):
 			self.log.debug("%s: Levelling up to %s", self, self.level)
 			self._update_level_data()
 
+			# update the level of our inhabitants so graphics can change
+			if self.has_component(CollectingComponent):
+				for collector in self.get_component(CollectingComponent).get_local_collectors():
+					collector.level_upgrade(self.level)
+
 			# Notify the world about the level up
 			SettlerUpdate.broadcast(self, self.level, 1)
 
@@ -340,6 +346,11 @@ class Settler(BuildableRect, BuildingResourceHandler, BasicBuilding):
 			self.get_component(StorageComponent).inventory.alter(RES.HAPPINESS, new_happiness)
 			self.log.debug("%s: Level down to %s", self, self.level)
 			self._changed()
+
+			# update the level of our inhabitants so graphics can change
+			if self.has_component(CollectingComponent):
+				for collector in self.get_component(CollectingComponent).get_local_collectors():
+					collector.level_upgrade(self.level)
 
 			# Notify the world about the level down
 			SettlerUpdate.broadcast(self, self.level, -1)

--- a/horizons/world/units/collectors/buildingcollector.py
+++ b/horizons/world/units/collectors/buildingcollector.py
@@ -313,6 +313,13 @@ class BuildingCollector(Collector):
 		while len(self._job_history) > 1 and self._job_history[1][0] < first_relevant_tick:
 			self._job_history.popleft()
 
+	def level_upgrade(self, lvl):
+		"""Upgrades collector to another tier"""
+		action_set = self.__class__.get_random_action_set(lvl, exact_level=True)
+		if action_set:
+			self._action_set_id = action_set
+			self.act(self._action, repeating=True)
+
 
 class StorageCollector(BuildingCollector):
 	""" Same as BuildingCollector, except that it moves on roads.


### PR DESCRIPTION
When a new tier is reached, a message is broadcasted to all buildings,
which lets them upgrade their level and with that their graphics.
Collectors are units, that belong to a building. This commit lets a
building tell its collectors, that its level has changed and their level
should be changed, too. Other than that, `BuildingCollector`s now also
have a `level_upgrade()` method to update their current `_action_set_id`
to a random one of the new level.

The corresponding issue is #2388.