### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{py,xml,json}]
+charset = utf-8
+indent_style = tab


### PR DESCRIPTION
The editorconfig file has builtin support by a couple editors with many plugins
adding support to others. This should make it easier for people to contribute
since there is no editor configuration necessary.