### PR TITLE
Enable code coverage tracking with coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,8 @@
 branch = True
 parallel = True
 source = horizons
+
+include =
+    horizons/*
+    run_uh.py
+    run_server.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,13 @@ install:
   - "cp -a /usr/lib/python2.7/dist-packages/fife/ $VIRTUAL_ENV/lib/python2.7/site-packages/"
   - "prename 's/\\.x86_64-linux-gnu//' $VIRTUAL_ENV/lib/python2.7/site-packages/fife/*.so"
   - "pip install -r requirements.txt"
+  - "pip install coverage coveralls"
 script: 
   - python -c 'from fife import fife; print fife.getVersion()'
-  - python run_tests.py --with-xunit --verbose --nologcapture
-  - python run_tests.py -a gui tests/gui --nologcapture
+  - COVERAGE_FILE=.coverage.nongui python run_tests.py --with-xunit --verbose --nologcapture --with-coverage
+  - RUNCOV=1 python run_tests.py -a gui tests/gui --nologcapture
+  - coverage combine
+  - coveralls
 notifications:
   irc: "irc.freenode.org#unknown-horizons"
   email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ============================================================
 
 [![Build Status](https://travis-ci.org/unknown-horizons/unknown-horizons.svg?branch=master)](https://travis-ci.org/unknown-horizons/unknown-horizons)
+[![Coverage Status](https://coveralls.io/repos/github/unknown-horizons/unknown-horizons/badge.svg?branch=master)](https://coveralls.io/github/unknown-horizons/unknown-horizons?branch=master)
  [![Bountysource](https://www.bountysource.com/badge/team?team_id=9261&style=bounties_received)](https://www.bountysource.com/teams/unknown-horizons/issues?utm_source=unknown-horizons&utm_medium=shield&utm_campaign=bounties_received)
  [![Translation status](https://hosted.weblate.org/widgets/uh/-/shields-badge.svg)](https://hosted.weblate.org/engage/uh/?utm_source=widget)
  [![#unknown-horizons on Freenode](https://img.shields.io/badge/freenode-%23unknown--horizons-green.svg)](https://webchat.freenode.net/?channels=unknown-horizons)


### PR DESCRIPTION
Two things happen here. For one, we're collecting coverage data from gui
tests (support initially added in 563f8d4a).
    
Since we're running the unit/integrationtests at first to get early
feedback, we need to set a different COVERAGE_FILE in order to combine
the coverage data with the one from the gui tests.
    
Once everything's done, send the combined coverage data to coveralls.