### PR TITLE
`else` clause on a loop without a `break` statement

### DIFF
--- a/horizons/gui/mousetools/tearingtool.py
+++ b/horizons/gui/mousetools/tearingtool.py
@@ -88,6 +88,7 @@ class TearingTool(NavigationTool):
 				self.session.view.renderer['InstanceRenderer'].removeColored(building._instance)
 				if (not building.id in BUILDINGS.EXPAND_RANGE) or self.confirm_ranged_delete(building):
 					Tear(building).execute(self.session)
+					break
 			else:
 				if self._hovering_over:
 					# we're hovering over a building, but none is selected, so this tear action isn't allowed

--- a/horizons/gui/mousetools/tearingtool.py
+++ b/horizons/gui/mousetools/tearingtool.py
@@ -84,11 +84,11 @@ class TearingTool(NavigationTool):
 				self.coords = coords
 			self._mark(self.coords, coords)
 			selection_list_copy = [building for building in self.selected]
-			for building in selection_list_copy:
-				self.session.view.renderer['InstanceRenderer'].removeColored(building._instance)
-				if (not building.id in BUILDINGS.EXPAND_RANGE) or self.confirm_ranged_delete(building):
-					Tear(building).execute(self.session)
-					break
+			if self.selected:
+				for building in selection_list_copy:
+					self.session.view.renderer['InstanceRenderer'].removeColored(building._instance)
+					if (not building.id in BUILDINGS.EXPAND_RANGE) or self.confirm_ranged_delete(building):
+						Tear(building).execute(self.session)
 			else:
 				if self._hovering_over:
 					# we're hovering over a building, but none is selected, so this tear action isn't allowed

--- a/horizons/gui/mousetools/tearingtool.py
+++ b/horizons/gui/mousetools/tearingtool.py
@@ -89,15 +89,14 @@ class TearingTool(NavigationTool):
 					self.session.view.renderer['InstanceRenderer'].removeColored(building._instance)
 					if (not building.id in BUILDINGS.EXPAND_RANGE) or self.confirm_ranged_delete(building):
 						Tear(building).execute(self.session)
-			else:
-				if self._hovering_over:
-					# we're hovering over a building, but none is selected, so this tear action isn't allowed
-					warehouses = [ b for b in self._hovering_over if
-					               b.id == BUILDINGS.WAREHOUSE and b.owner.is_local_player]
-					if warehouses:
-						# tried to tear a warehouse, this is especially non-tearable
-						pos = warehouses[0].position.origin
-						self.session.ingame_gui.message_widget.add(point=pos, string_id="WAREHOUSE_NOT_TEARABLE" )
+			elif self._hovering_over:
+				# we're hovering over a building, but none is selected, so this tear action isn't allowed
+				warehouses = [ b for b in self._hovering_over if
+					       b.id == BUILDINGS.WAREHOUSE and b.owner.is_local_player]
+				if warehouses:
+					# tried to tear a warehouse, this is especially non-tearable
+					pos = warehouses[0].position.origin
+					self.session.ingame_gui.message_widget.add(point=pos, string_id="WAREHOUSE_NOT_TEARABLE" )
 
 			self.selected = WeakList()
 			self._hovering_over = WeakList()


### PR DESCRIPTION
have add a break statement.
All tests are fine, but I found no test for only this unit.

The else clause of a loop is executed when the loop sequence is empty. When a loop specifies no break statement, the else clause will always execute, because the loop sequence will eventually always become empty. Sometimes this is the intended behavior, in which case you can ignore this error. But most times this is not the intended behavior, and you should therefore review the code in question.

```
def contains_magic_number(list, magic_number):
    for i in list:
        if i == magic_number:
            print "This list contains the magic number."
    else:
        print "This list does NOT contain the magic number."

contains_magic_number(range(10), 5)
# This list contains the magic number.
# This list does NOT contain the magic number.

# add a break statement 
def contains_magic_number(list, magic_number):
    for i in list:
        if i == magic_number:
            print "This list contains the magic number."
            break  # added break statement here
    else:
        print "This list does NOT contain the magic number."

contains_magic_number(range(10), 5)
# This list contains the magic number.
```
https://www.quantifiedcode.com/app/issue_class/4aqWoDeY