### PR TITLE
default arguments should not use a list

### DIFF
--- a/horizons/util/python/decorators.py
+++ b/horizons/util/python/decorators.py
@@ -109,7 +109,8 @@ def temporary_cachedmethod(timeout):
 
 globals().update(opmap)
 
-def _make_constants(f, builtin_only=False, stoplist=[], verbose=False):
+def _make_constants(f, builtin_only=False, stoplist=None, verbose=False):
+	stoplist = stoplist or []
 	try:
 		co = f.func_code
 	except AttributeError:

--- a/horizons/util/python/decorators.py
+++ b/horizons/util/python/decorators.py
@@ -242,7 +242,7 @@ def bind_all(mc, builtin_only=False, stoplist=None, verbose=False):
 			bind_all(v, builtin_only, stoplist, verbose)
 
 @_make_constants
-def make_constants(builtin_only=False, stoplist=[], verbose=False):
+def make_constants(builtin_only=False, stoplist=None, verbose=False):
 	""" Return a decorator for optimizing global references.
 
 	Replaces global references with their currently defined values.
@@ -253,6 +253,7 @@ def make_constants(builtin_only=False, stoplist=[], verbose=False):
 	If verbose is True, prints each substitution as is occurs
 
 	"""
+	stoplist = stoplist or []
 	if type(builtin_only) == type(make_constants):
 		raise ValueError("The bind_constants decorator must have arguments.")
 	return lambda f: _make_constants(f, builtin_only, stoplist, verbose)


### PR DESCRIPTION
Mutable list used as default argument to a function. Python creates a single persistent object and uses it for every subsequent call in which the argument is left empty. This can cause problems if the program was expecting the function to return a new list after every call.

https://www.quantifiedcode.com/app/issue_class/3P0qV6OB
