### PR TITLE
Fix production overview not showing produced resources

### DIFF
--- a/horizons/world/production/producer.py
+++ b/horizons/world/production/producer.py
@@ -59,6 +59,7 @@ class Producer(Component):
 	    'FullUtilization': FullUtilization
 	}
 
+	produces_resource = True
 	production_class = Production
 
 	# INIT
@@ -557,6 +558,7 @@ class QueueProducer(Producer):
 class ShipProducer(QueueProducer):
 	"""Uses queues to produce naval units"""
 
+	produces_resource = False
 	production_class = UnitProduction
 
 	def get_unit_production_queue(self):
@@ -608,6 +610,8 @@ class ShipProducer(QueueProducer):
 
 class GroundUnitProducer(ShipProducer):
 	"""Uses queues to produce groundunits"""
+
+	produces_resource = False
 
 	def _place_unit(self, unit):
 		radius = 1

--- a/horizons/world/settlement.py
+++ b/horizons/world/settlement.py
@@ -216,8 +216,8 @@ class Settlement(ComponentHolder, WorldObject, ChangeListener, ResourceHandler):
 			self.buildings_by_id[building.id].append(building)
 		else:
 			self.buildings_by_id[building.id] = [building]
-		if building.has_component(Producer) and not \
-		   building.has_component(ShipProducer) and not building.has_component(GroundUnitProducer):
+		component = building.get_component(Producer)
+		if component and component.produces_resource:
 			finished = self.settlement_building_production_finished
 			building.get_component(Producer).add_production_finished_listener(finished)
 		if not load and not building.buildable_upon and self.buildability_cache:
@@ -233,8 +233,8 @@ class Settlement(ComponentHolder, WorldObject, ChangeListener, ResourceHandler):
 			return
 		self.buildings.remove(building)
 		self.buildings_by_id[building.id].remove(building)
-		if building.has_component(Producer) and not \
-		   building.has_component(ShipProducer) and not building.has_component(GroundUnitProducer):
+		component = building.get_component(Producer)
+		if component and component.produces_resource:
 			finished = self.settlement_building_production_finished
 			building.get_component(Producer).remove_production_finished_listener(finished)
 		if not building.buildable_upon and self.buildability_cache:


### PR DESCRIPTION
I'm fairly certain the issue was introduced in 14121bcb56f50f01231,
which was a fix for #1848 [1].

The issue is that both `ShipProducer` and `GroundUnitProducer` inherit
from `Producer`, but keep the same component name.
`ComponentHolder.has_component` checks existance of a component by
looking for the name. Which means that a condition like

  has_component(Producer) and not has_component(ShipProducer)

is always false, since both components have the same name "producer".

Fix this by specifying on the specific producer components whether or
not they actually produce a resource, and use that to decide whether it
should show up in the production overview or not.

Fixes #2369

[1] https://github.com/unknown-horizons/unknown-horizons/issues/1848