### PR TITLE
Make hack for filtering out map preview data look nicer

### DIFF
--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 import itertools
 import json
 import math
-import re
 from math import cos, sin
 
 from fife import fife
@@ -190,8 +189,8 @@ class Minimap(object):
 			ExtScheduler().add_new_object(self._timed_update, self,
 			                              self.SHIP_DOT_UPDATE_INTERVAL, -1)
 
-	def dump_data(self):
-		"""Returns a string representing the minimap data"""
+	def get_data(self):
+		"""Returns a list representing the minimap data"""
 		return self._recalculate(dump_data=True)
 
 	def draw_data(self, data):
@@ -206,12 +205,7 @@ class Minimap(object):
 		draw_point = rt.addPoint
 		point = fife.Point()
 
-		# XXX There have been reports about `data` containing Fife debug
-		# output (e.g. #2193). As temporary workaround, we try to only
-		# parse what looks like valid json in there and ignore the rest.
-		found_json = re.findall(r'\[\[.*\]\]', data)[0]
-
-		for x, y, r, g, b in json.loads(found_json):
+		for x, y, r, g, b in data:
 			point.set(x, y)
 			draw_point(render_name, point, r, g, b)
 
@@ -553,7 +547,7 @@ class Minimap(object):
 				draw_point(render_name, fife_point, *color)
 
 		if dump_data:
-			return json.dumps(data)
+			return data
 
 
 	def _timed_update(self, force=False):


### PR DESCRIPTION
In 6471ad0cf5be8c a hack was introduced to filter out the map data
written onto stdout from a subprocess. Sometimes more output is
generated by the subprocess, making it impossible to simply parse the
whole output as JSON.

While we could try to prevent any other output from happening (and
risking to break the map preview whenever some output leaks), or trying
to do something fancy (write into temporary files, pass a pipe.. does
that work windows?) ... at the end of the day, using stdout proved to be
working fine.

By moving some code around, and keeping serialization at the upmost
layer of the application, the communication and "protocol" is
selfcontained inside the singleplayermenu module.

Closes #2193