### PR TITLE
Make render name of icons more unique to prevent crash

### DIFF
--- a/horizons/world/managers/productionfinishediconmanager.py
+++ b/horizons/world/managers/productionfinishediconmanager.py
@@ -19,6 +19,8 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import uuid
+
 from fife import fife
 
 import horizons.globals
@@ -152,4 +154,4 @@ class ProductionFinishedIconManager(object):
 		This key MUST be unique!
 		"""
 		return "produced_resource_" + str(res) + "_" + str(instance.position.origin)\
-		       + "_" + str(Scheduler().cur_tick)
+		       + "_" + str(uuid.uuid1())


### PR DESCRIPTION
Fixes #2475 

---

I guess we could safely drop at least one other parameter of `get_resource_string`, but I suppose it can't hurt to keep it?