### PR TITLE
Fix one possible cause of hangups when closing the game window

### DIFF
--- a/horizons/gui/keylisteners/mainlistener.py
+++ b/horizons/gui/keylisteners/mainlistener.py
@@ -97,5 +97,8 @@ class MainListener(fife.IKeyListener, fife.ICommandListener, LivingObject):
 
 	def onCommand(self, command):
 		if command.getCommandType() == fife.CMD_QUIT_GAME:
-			horizons.main.quit()
+			# NOTE Sometimes we get two quit events from FIFE, ignore the second
+			#      when we already shutting down the game
+			if not horizons.globals.fife.quit_requested:
+				horizons.main.quit()
 			command.consume()


### PR DESCRIPTION
I don't know why, but when closing the game by either clicking the
windows' close button (think windows or ubuntu) or using a shortcut of
the window manager, fife dispatches 2 quit commands.

This will trigger `horizons.main.quit` two times, which in turn will
attempt to join the preloading thread two times. Before joining, the
code in `preload_game_join` attempts to acquire the lock, which will
cause the hangup. The reason why the join function needs to acquire the
lock first is another mistery to me.

Regardless, we shouldn't handle the two quit commands. Once we initiated
shutdown, we can ignore the second command.

Refs #2466