### PR TITLE
Fix crash when closing game while route config is open

### DIFF
--- a/horizons/gui/widgets/routeconfig.py
+++ b/horizons/gui/widgets/routeconfig.py
@@ -60,8 +60,10 @@ class RouteConfig(Window):
 		if not hasattr(instance, 'route'):
 			CreateRoute(instance).execute(self.session)
 
-		# We must make sure that the createRoute command has successfully finished, even in network games.
-		Scheduler().add_new_object(self._init_gui, self, run_in=MPManager.EXECUTIONDELAY+2)
+			# We must make sure that the createRoute command has successfully finished, even in network games.
+			Scheduler().add_new_object(self._init_gui, self, run_in=MPManager.EXECUTIONDELAY+2)
+		else:
+			self._init_gui()
 
 	@property
 	def session(self):

--- a/horizons/gui/widgets/routeconfig.py
+++ b/horizons/gui/widgets/routeconfig.py
@@ -90,7 +90,10 @@ class RouteConfig(Window):
 
 		# make sure user knows that it's not enabled (if it appears to be complete)
 		if not self.instance.route.enabled and self.instance.route.can_enable():
-			self.session.ingame_gui.message_widget.add('ROUTE_DISABLED')
+			# If message_widget is not defined anymore, we're closing the game right
+			# now
+			if self.session.ingame_gui.message_widget:
+				self.session.ingame_gui.message_widget.add('ROUTE_DISABLED')
 
 	def on_instance_removed(self):
 		self._windows.close()

--- a/tests/gui/ingame/test_traderoute.py
+++ b/tests/gui/ingame/test_traderoute.py
@@ -96,3 +96,13 @@ def test_traderoute(gui):
 	assert Point(38, 39) in ship.route.waypoints[0]['warehouse'].position
 	assert Point(15, 26) in ship.route.waypoints[1]['warehouse'].position
 	assert ship.route.waypoints[1]['resource_list'] == {RES.FOOD: 120}
+
+	# Since this test is rather complex, we test bug #2525 as well
+
+	# open pause menu and quit
+	gui.trigger('mainhud/gameMenuButton')
+	def func1():
+		gui.trigger('popup_window/okButton')
+
+	with gui.handler(func1):
+		gui.trigger('menu/closeButton')


### PR DESCRIPTION
Fixes #2525 

---

While this fixes the bug (and doesn't seem to break anything else), it isn't a proper solution really. Currently, I assume most widgets do not differentiate between beeing hidden and hiding them because the game is closing.
Then again, perhaps the route config is an outlier here, as it interacts with the GUI (message_widget) when it is beeing hidden.