### PR TITLE
Fix space issues in production overview

### DIFF
--- a/content/gui/xml/ingame/widgets/island_production.xml
+++ b/content/gui/xml/ingame/widgets/island_production.xml
@@ -1,27 +1,20 @@
 <?xml version="1.0"?>
 <Container name="production_overview" size="800,580" position_technique="center:center"
 	background_image="content/gui/images/background/book.png">
+	<Label name="headline" min_size="300,20" position="70,33" />
+	<hr position="70,53" />
 
-	<VBox max_size="695,508" min_size="695,508" position="72,40" padding="5">
-		<HBox>
-			<Label name="headline" min_size="300,20" />
+	<VBox max_size="330,430" min_size="330,430" name="page_left" position="70,70" />
+	<VBox max_size="330,430" min_size="330,430" name="page_right" position="420,70" />
+
+	<HBox max_size="660,40" min_size="660,40" position="70,510">
+		<HBox max_size="80,36">
+			<ImageButton name="backwardButton" helptext="Go to previous page"
+				path="images/buttons/parrow_left" />
+			<ImageButton name="forwardButton" helptext="Go to next page"
+				path="images/buttons/parrow_right" />
 		</HBox>
-		<hr />
-
-		<VBox name="content_vbox" />
-<!--
-In this VBox a line is added per sensible resource in the following format:
-		<HBox>
-			<Icon image="content/gui/icons/resources/32/4.png" max_size="16,16" min_size="16,16" size="16,16" />
-			<Label max_size="70, 20" min_size="70,20" name="resource_4"  text="Boards" />
-			<Label name="produced_sum_4"  text="17314" />
-		</HBox>
--->
-
 		<Spacer />
-		<HBox>
-			<Spacer min_size="627" />
-			<OkButton helptext="Close" />
-		</HBox>
-	</VBox>
+		<OkButton helptext="Close" />
+	</HBox>
 </Container>

--- a/content/gui/xml/ingame/widgets/island_production.xml
+++ b/content/gui/xml/ingame/widgets/island_production.xml
@@ -4,8 +4,8 @@
 	<Label name="headline" min_size="300,20" position="70,33" />
 	<hr position="70,53" />
 
-	<VBox max_size="330,430" min_size="330,430" name="page_left" position="70,70" />
-	<VBox max_size="330,430" min_size="330,430" name="page_right" position="420,70" />
+	<VBox max_size="300,400" min_size="300,400" padding="12" name="page_left" position="100,100" />
+	<VBox max_size="300,400" min_size="300,400" padding="12" name="page_right" position="450,100" />
 
 	<HBox max_size="660,40" min_size="660,40" position="70,510">
 		<HBox max_size="80,36">

--- a/horizons/gui/util.py
+++ b/horizons/gui/util.py
@@ -144,6 +144,7 @@ def create_resource_icon(res_id, db):
 	@param db: dbreader for main db"""
 	widget = Icon(image=get_res_icon_path(res_id))
 	widget.helptext = db.get_res_name(res_id)
+	widget.scale = True
 	return widget
 
 

--- a/horizons/gui/widgets/productionoverview.py
+++ b/horizons/gui/widgets/productionoverview.py
@@ -61,7 +61,7 @@ class ProductionOverview(MultiPageStatsWidget, Window):
 
 	Implementation based on https://github.com/unknown-horizons/unknown-horizons/issues/749 .
 	"""
-	LINES_PER_PAGE = 19
+	LINES_PER_PAGE = 12
 
 	widget_file_name = 'island_production.xml'
 

--- a/horizons/gui/widgets/productionoverview.py
+++ b/horizons/gui/widgets/productionoverview.py
@@ -19,13 +19,14 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import math
 from operator import itemgetter
 
 from fife.extensions.pychan import widgets
 
 from horizons.component.namedcomponent import NamedComponent
 from horizons.constants import GAME_SPEED
-from horizons.gui.util import create_resource_icon
+from horizons.gui.util import create_resource_icon, load_uh_widget
 from horizons.gui.widgets.imagebutton import OkButton
 from horizons.gui.widgets.statswidget import StatsWidget
 from horizons.gui.windows import Window
@@ -34,12 +35,33 @@ from horizons.util.python import decorators
 from horizons.util.python.callback import Callback
 
 
-class ProductionOverview(StatsWidget, Window):
+class MultiPageStatsWidget(StatsWidget):
+	"""
+	A widget that creates a large table with statistics that can be browsed through page by
+	page.
+	"""
+	widget_file_name = None # name of the widget's XML file
+
+	def _init_gui(self):
+		self._gui = load_uh_widget(self.widget_file_name, center_widget=self.center_widget)
+		if not self.center_widget:
+			self._gui.position_technique = 'center+20:center+25'
+		self._page_left = self._gui.findChild(name='page_left')
+		self._page_right = self._gui.findChild(name='page_right')
+		self.refresh()
+
+	def _clear_entries(self):
+		self._page_left.removeAllChildren()
+		self._page_right.removeAllChildren()
+
+
+class ProductionOverview(MultiPageStatsWidget, Window):
 	"""
 	Widget that shows every produced resource in this game.
 
 	Implementation based on https://github.com/unknown-horizons/unknown-horizons/issues/749 .
 	"""
+	LINES_PER_PAGE = 19
 
 	widget_file_name = 'island_production.xml'
 
@@ -47,6 +69,7 @@ class ProductionOverview(StatsWidget, Window):
 		StatsWidget.__init__(self, settlement.session, center_widget=True)
 		Window.__init__(self, windows)
 
+		self.current_page = 0
 		self.settlement = settlement
 		self.db = self.settlement.session.db
 		Scheduler().add_new_object(Callback(self._refresh_tick), self, run_in=GAME_SPEED.TICKS_PER_SECOND, loops=-1)
@@ -54,19 +77,57 @@ class ProductionOverview(StatsWidget, Window):
 	def _init_gui(self):
 		super(ProductionOverview, self)._init_gui()
 		self._gui.findChild(name=OkButton.DEFAULT_NAME).capture(self._windows.close)
+		self._gui.findChild(name='forwardButton').capture(self.go_to_next_page)
+		self._gui.findChild(name='backwardButton').capture(self.go_to_previous_page)
+
+	@property
+	def max_pages(self):
+		return int(math.ceil(len(self.settlement.produced_res) / float(self.LINES_PER_PAGE)))
+
+	def go_to_next_page(self):
+		self.current_page = min(self.max_pages - 1, self.current_page + 2)
+		self.refresh()
+
+	def go_to_previous_page(self):
+		self.current_page = max(0, self.current_page - 2)
+		self.refresh()
 
 	def refresh(self):
 		super(ProductionOverview, self).refresh()
+
+		data = sorted(self.settlement.produced_res.items(), key=itemgetter(1), reverse=True)
+
 		name = self.settlement.get_component(NamedComponent).name
 		text = _('Production overview of {settlement}').format(settlement=name)
 		self._gui.findChild(name='headline').text = text
 
-		data = sorted(self.settlement.produced_res.items(), key=itemgetter(1), reverse=True)
-		for resource_id, amount in data:
-			self._add_line_to_gui(resource_id, amount)
-		self._content_vbox.adaptLayout()
+		forward_button = self._gui.findChild(name='forwardButton')
+		backward_button = self._gui.findChild(name='backwardButton')
 
-	def _add_line_to_gui(self, resource_id, amount):
+		if self.current_page == 0:
+			backward_button.set_inactive()
+		else:
+			backward_button.set_active()
+
+		if self.current_page == self.max_pages - 1:
+			forward_button.set_inactive()
+		else:
+			forward_button.set_active()
+
+		data = data[self.current_page * self.LINES_PER_PAGE:(self.current_page + 2) * self.LINES_PER_PAGE]
+
+		for idx, (resource_id, amount) in enumerate(data, start=1):
+			if idx > self.LINES_PER_PAGE:
+				container = self._page_right
+			else:
+				container = self._page_left
+
+			self._add_line_to_gui(container, resource_id, amount)
+
+		self._page_left.adaptLayout()
+		self._page_right.adaptLayout()
+
+	def _add_line_to_gui(self, container, resource_id, amount):
 		displayed = self.db.get_res_inventory_display(resource_id)
 		if not displayed:
 			return
@@ -87,6 +148,6 @@ class ProductionOverview(StatsWidget, Window):
 		hbox.addChild(icon)
 		hbox.addChild(label)
 		hbox.addChild(amount_label)
-		self._content_vbox.addChild(hbox)
+		container.addChild(hbox)
 
 decorators.bind_all(ProductionOverview)


### PR DESCRIPTION
Fixes #2169 

- [x] fix page scrolling
- [x] add more padding, use more whitespace (that means less than 19 rows per page)
- [x] handle hidden resources (avoid creating blank space and switching to next page too early)