### PR TITLE
Codestyle multiple statements on one line

### DIFF
--- a/development/compare_string_lengths_in_pos.py
+++ b/development/compare_string_lengths_in_pos.py
@@ -71,8 +71,10 @@ for t in translations:
 	if orig.startswith("#") or trans.startswith("#"):
 		continue
 
-	if orig.startswith("msgid"): orig = orig[6:]
-	if trans.startswith("msgstr"): trans = trans[7:]
+	if orig.startswith("msgid"):
+		orig = orig[6:]
+	if trans.startswith("msgstr"):
+		trans = trans[7:]
 
 	if trans == "\"\"":
 		continue

--- a/horizons/gui/ingamegui.py
+++ b/horizons/gui/ingamegui.py
@@ -493,7 +493,8 @@ class IngameGui(LivingObject):
 		elif action == _Actions.LOGBOOK:
 			self.windows.toggle(self.logbook)
 		elif action == _Actions.DEBUG and VERSION.IS_DEV_VERSION:
-			import pdb; pdb.set_trace()
+			import pdb
+			pdb.set_trace()
 		elif action == _Actions.BUILD_TOOL:
 			self.show_build_menu()
 		elif action == _Actions.ROTATE_RIGHT:

--- a/horizons/gui/keylisteners/ingamekeylistener.py
+++ b/horizons/gui/keylisteners/ingamekeylistener.py
@@ -51,13 +51,13 @@ class IngameKeyListener(fife.IKeyListener, LivingObject):
 	def updateAutoscroll(self):
 		self.key_scroll = [0, 0]
 		if self.up_key_pressed:
-			self.key_scroll[1] -= self.key_scroll_speed;
+			self.key_scroll[1] -= self.key_scroll_speed
 		if self.down_key_pressed:
-			self.key_scroll[1] += self.key_scroll_speed;
+			self.key_scroll[1] += self.key_scroll_speed
 		if self.left_key_pressed:
-			self.key_scroll[0] -= self.key_scroll_speed;
+			self.key_scroll[0] -= self.key_scroll_speed
 		if self.right_key_pressed:
-			self.key_scroll[0] += self.key_scroll_speed;
+			self.key_scroll[0] += self.key_scroll_speed
 
 		self.session.view.autoscroll_keys(*self.key_scroll)
 

--- a/horizons/gui/modules/playerdataselection.py
+++ b/horizons/gui/modules/playerdataselection.py
@@ -63,7 +63,7 @@ class PlayerDataSelection(object):
 		playertextfield = self.gui.findChild(name='playername')
 		def playertextfield_clicked():
 			if playertextfield.text == 'Unnamed Traveler':
-				playertextfield.text = "";
+				playertextfield.text = ""
 		playertextfield.capture(playertextfield_clicked, event_name='mouseClicked')
 
 		self.gui.mapEvents(events)

--- a/horizons/gui/tabs/buildtabs.py
+++ b/horizons/gui/tabs/buildtabs.py
@@ -262,7 +262,7 @@ class BuildTab(TabInterface):
 
 		#save build style
 		horizons.globals.fife.set_uh_setting("Buildstyle",new_index)
-		horizons.globals.fife.save_settings();
+		horizons.globals.fife.save_settings()
 
 	@classmethod
 	def create_tabs(cls, session, build_callback):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,5 @@ attr=!long,!gui
 [pep8]
 select = W291, W391, E70
 # https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-ignore = E101, W191, W503
-# W503 ignore info is at: https://github.com/unknown-horizons/unknown-horizons/pull/2532
+ignore = E101, W191
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ desktop_files=[('share/applications', 'po/uh/', ('content/packages/unknown-horiz
 traverse-namespace=1
 attr=!long,!gui
 [pep8]
-select = W291, W391
+select = W291, W391, E70
 # https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-ignore = E101,W191
+ignore = E101, W191, W503
+# W503 ignore info is at: https://github.com/unknown-horizons/unknown-horizons/pull/2532
 max-line-length = 100


### PR DESCRIPTION
If it ok to solve the Codestyle E701 - E704, I can make it, today.

This are the line to change:
```
horizons/gui/ingamegui.py:496:14: E702 multiple statements on one line (semicolon)
horizons/gui/modules/playerdataselection.py:66:30: E703 statement ends with a semicolon
horizons/gui/tabs/buildtabs.py:265:40: E703 statement ends with a semicolon
horizons/gui/keylisteners/ingamekeylistener.py:54:47: E703 statement ends with a semicolon
horizons/gui/keylisteners/ingamekeylistener.py:56:47: E703 statement ends with a semicolon
horizons/gui/keylisteners/ingamekeylistener.py:58:47: E703 statement ends with a semicolon
horizons/gui/keylisteners/ingamekeylistener.py:60:47: E703 statement ends with a semicolon
development/compare_string_lengths_in_pos.py:74:29: E701 multiple statements on one line (colon)
development/compare_string_lengths_in_pos.py:75:31: E701 multiple statements on one line (colon)
```