### PR TITLE
Rewrite step slider to accept discrete steps on construction

### DIFF
--- a/content/gui/xml/mainmenu/singleplayer/sp_random.xml
+++ b/content/gui/xml/mainmenu/singleplayer/sp_random.xml
@@ -9,23 +9,23 @@
 		</HBox>
 		<HBox name="map_size">
 			<Label name="map_size_lbl" min_size="150,20" />
-			<StepSlider name="map_size_slider" size="125,20" scale_start="0" scale_end="4" step_length="1" marker_length="25" is_focusable="0" />
+			<StepSlider name="map_size_slider" size="125,20" steps="50 ; 100 ; 150 ; 200 ; 250" marker_length="25" is_focusable="0" />
 		</HBox>
 		<HBox name="water_percent">
 			<Label name="water_percent_lbl" min_size="150,20" />
-			<StepSlider name="water_percent_slider" size="125,20" scale_start="0" scale_end="6" step_length="1" marker_length="22" is_focusable="0" />
+			<StepSlider name="water_percent_slider" size="125,20" steps="20 ; 30 ; 40 ; 50 ; 60 ; 70 ; 80" marker_length="22" is_focusable="0" />
 		</HBox>
 		<HBox name="max_island_size">
 			<Label name="max_island_size_lbl" min_size="150,20" />
-			<StepSlider name="max_island_size_slider" size="125,20" scale_start="0" scale_end="4" step_length="1" marker_length="25" is_focusable="0" />
+			<StepSlider name="max_island_size_slider" size="125,20" steps="30 ; 40 ; 50 ; 60 ; 70 ; 80" marker_length="25" is_focusable="0" />
 		</HBox>
 		<HBox name="preferred_island_size">
 			<Label name="preferred_island_size_lbl" min_size="150,20" />
-			<StepSlider name="preferred_island_size_slider" size="125,20" scale_start="0" scale_end="4" step_length="1" marker_length="25" is_focusable="0" />
+			<StepSlider name="preferred_island_size_slider" size="125,20" steps="30 ; 40 ; 50 ; 60 ; 70 ; 80" marker_length="25" is_focusable="0" />
 		</HBox>
 		<HBox name="island_size_deviation">
 			<Label name="island_size_deviation_lbl" min_size="150,20" />
-			<StepSlider name="island_size_deviation_slider" size="125,20" scale_start="0" scale_end="4" step_length="1" marker_length="25" is_focusable="0" />
+			<StepSlider name="island_size_deviation_slider" size="125,20" steps="5 ; 10 ; 20 ; 30 ; 40" marker_length="25" is_focusable="0" />
 		</HBox>
 	</VBox>
 

--- a/content/gui/xml/mainmenu/templates/game_settings.xml
+++ b/content/gui/xml/mainmenu/templates/game_settings.xml
@@ -4,7 +4,7 @@
 
 	<HBox name="resource_density">
 		<Label name="resource_density_lbl" min_size="150,20" />
-		<StepSlider name="resource_density_slider" size="125,20" scale_start="0" scale_end="4" step_length="1" marker_length="25" is_focusable="0" />
+		<StepSlider name="resource_density_slider" size="125,20" steps="0.5 ; 0.7 ; 1 ; 1.4 ; 2" marker_length="25" is_focusable="0" />
 	</HBox>
 
 	<HBox name="game_setting_checkboxes">

--- a/horizons/gui/modules/singleplayermenu.py
+++ b/horizons/gui/modules/singleplayermenu.py
@@ -122,8 +122,6 @@ class SingleplayerMenu(Window):
 class GameSettingsWidget(object):
 	"""Toggle trader/pirates/disasters and change resource density."""
 
-	resource_densities = [0.5, 0.7, 1, 1.4, 2]
-
 	def __init__(self):
 		self._gui = load_uh_widget('game_settings.xml')
 
@@ -152,11 +150,13 @@ class GameSettingsWidget(object):
 			self._gui.findChild(name=u'lbl_' + setting).capture(Callback(toggle, setting, setting_save_name))
 
 		resource_density_slider = self._gui.findChild(name='resource_density_slider')
+
 		def on_resource_density_slider_change():
 			self._gui.findChild(name='resource_density_lbl').text = _('Resource density:') + u' ' + \
-				unicode(self.resource_densities[int(resource_density_slider.value)]) + u'x'
+				unicode(resource_density_slider.value) + u'x'
 			horizons.globals.fife.set_uh_setting("MapResourceDensity", resource_density_slider.value)
 			horizons.globals.fife.save_settings()
+
 		resource_density_slider.capture(on_resource_density_slider_change)
 		resource_density_slider.value = horizons.globals.fife.get_uh_setting("MapResourceDensity")
 
@@ -164,7 +164,7 @@ class GameSettingsWidget(object):
 
 	@property
 	def natural_resource_multiplier(self):
-		return self.resource_densities[int(self._gui.findChild(name='resource_density_slider').value)]
+		return self._gui.findChild(name='resource_density_slider').value
 
 	@property
 	def free_trader(self):
@@ -181,11 +181,6 @@ class GameSettingsWidget(object):
 
 class RandomMapWidget(object):
 	"""Create a random map, influence map generation with multiple sliders."""
-
-	map_sizes = [50, 100, 150, 200, 250]
-	water_percents = [20, 30, 40, 50, 60, 70, 80]
-	island_sizes = [30, 40, 50, 60, 70]
-	island_size_deviations = [5, 10, 20, 30, 40]
 
 	def __init__(self, windows, singleplayer_menu, aidata):
 		self._windows = windows
@@ -231,31 +226,31 @@ class RandomMapWidget(object):
 		seed_string_field.text = generate_random_seed(seed_string_field.text)
 
 		parameters = (
-			('map_size', self.map_sizes, _('Map size:'), 'RandomMapSize'),
-			('water_percent', self.water_percents, _('Water:'), 'RandomMapWaterPercent'),
-			('max_island_size', self.island_sizes, _('Max island size:'), 'RandomMapMaxIslandSize'),
-			('preferred_island_size', self.island_sizes, _('Preferred island size:'), 'RandomMapPreferredIslandSize'),
-			('island_size_deviation', self.island_size_deviations, _('Island size deviation:'), 'RandomMapIslandSizeDeviation'),
+			('map_size', _('Map size:'), 'RandomMapSize'),
+			('water_percent', _('Water:'), 'RandomMapWaterPercent'),
+			('max_island_size', _('Max island size:'), 'RandomMapMaxIslandSize'),
+			('preferred_island_size', _('Preferred island size:'), 'RandomMapPreferredIslandSize'),
+			('island_size_deviation', _('Island size deviation:'), 'RandomMapIslandSizeDeviation'),
 		)
 
-		for param, __, __, setting_name in parameters:
+		for param, __, setting_name in parameters:
 			self._map_parameters[param] = horizons.globals.fife.get_uh_setting(setting_name)
 
-		def make_on_change(param, values, text, setting_name):
+		def make_on_change(param, text, setting_name):
 			# When a slider is changed, update the value displayed in the label, save the value
 			# in the settings and store the value in self._map_parameters
 			def on_change():
 				slider = self._gui.findChild(name=param + '_slider')
-				self._gui.findChild(name=param + '_lbl').text = text + u' ' + unicode(values[int(slider.value)])
+				self._gui.findChild(name=param + '_lbl').text = text + u' ' + unicode(int(slider.value))
 				horizons.globals.fife.set_uh_setting(setting_name, slider.value)
 				horizons.globals.fife.save_settings()
 				self._on_random_parameter_changed()
-				self._map_parameters[param] = values[int(slider.value)]
+				self._map_parameters[param] = int(slider.value)
 			return on_change
 
-		for param, values, text, setting_name in parameters:
+		for param, text, setting_name in parameters:
 			slider = self._gui.findChild(name=param + '_slider')
-			on_change = make_on_change(param, values, text, setting_name)
+			on_change = make_on_change(param, text, setting_name)
 			slider.capture(on_change)
 			slider.value = horizons.globals.fife.get_uh_setting(setting_name)
 			on_change()

--- a/horizons/gui/tabs/residentialtabs.py
+++ b/horizons/gui/tabs/residentialtabs.py
@@ -107,9 +107,9 @@ class SettlerOverviewTab(OverviewTab):
 
 def setup_tax_slider(slider, val_label, settlement, level):
 	"""Set up a slider to work as tax slider"""
-	slider.scale_start = SETTLER.TAX_SETTINGS_MIN
-	slider.scale_end = SETTLER.TAX_SETTINGS_MAX
-	slider.step_length = SETTLER.TAX_SETTINGS_STEP
+	step_count = int((SETTLER.TAX_SETTINGS_MAX - SETTLER.TAX_SETTINGS_MIN) / SETTLER.TAX_SETTINGS_STEP)
+	slider.steps = [SETTLER.TAX_SETTINGS_MIN + SETTLER.TAX_SETTINGS_STEP * i for i in
+			range(step_count)]
 	slider.value = settlement.tax_settings[level]
 	def on_slider_change():
 		val_label.text = unicode(slider.value)

--- a/horizons/gui/widgets/stepslider.py
+++ b/horizons/gui/widgets/stepslider.py
@@ -19,32 +19,89 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-
-from fife.extensions.pychan.widgets import Slider
+from fife.extensions.pychan.attrs import IntAttr, UnicodeAttr
+from fife.extensions.pychan.widgets import Slider, Widget
 
 
 class StepSlider(Slider):
+	"""The StepSlider automatically snaps the steps suggested by stepsize."""
+
+	ATTRIBUTES = Widget.ATTRIBUTES + [
+		IntAttr('orientation'),
+		IntAttr('marker_length'),
+		UnicodeAttr('steps')]
 
 	def __init__(self, *args, **kwargs):
-		"""The StepSlider automatically snaps the steps suggested by stepsize."""
-		self.__callbacks_by_group = {} # super init calls capture, so we need this here
+		self._callbacks_by_group = {} # super init calls capture, so we need this here
 
 		super(StepSlider, self).__init__(*args, **kwargs)
 
-		self.__last_step_value = None # for recognizing new steps, self.value is overwritten in the base class sometimes
-		self.capture(None)
+		self._last_step_value = None # for recognizing new steps, self.value is overwritten in the base class sometimes
+		self._steps = None
 
-	def capture(self, callback, event_name="action", group_name="default"):
-		if event_name == "action":
-			super(StepSlider, self).capture(self.__update, event_name, group_name="stepslider")
-			self.__callbacks_by_group[group_name] = callback
+		super(StepSlider, self).capture(self._update, 'action', 'stepslider')
+		super(StepSlider, self).capture(self._mouse_released_snap, 'mouseReleased', 'stepslider')
+
+	def _mouse_released_snap(self):
+		"""
+		When mouse is released, snap slider marker to discrete value to avoid the marker
+		being displayed in-between steps.
+		"""
+		# Retrieve the value of the step that is closest to marker's current position
+		# (`_get_value`), and set that value on the slider to move the marker (`_set_value`).
+		self.value = self.value
+
+	def capture(self, callback, event_name='action', group_name='default'):
+		"""
+		Intercept captures for `action` and store the callback in our list. We'll only
+		call them when a step changed.
+		"""
+		if event_name == 'action':
+			self._callbacks_by_group[group_name] = callback
 		else:
 			super(StepSlider, self).capture(callback, event_name, group_name)
 
-	def __update(self):
-		value = round(self.value / self.step_length) * self.step_length
-		if value != self.__last_step_value:
-			self.__last_step_value = value
-			self.value = value # has be overwritten before this has been called
-			for callback in self.__callbacks_by_group.itervalues():
+	def _update(self):
+		"""
+		Notify listeners when a different step was selected.
+		"""
+		if self.value != self._last_step_value:
+			self._last_step_value = self.value
+			for callback in self._callbacks_by_group.itervalues():
 				callback()
+
+	def _set_steps(self, steps):
+		if isinstance(steps, basestring):
+			self._steps = [float(s.strip()) for s in steps.split(';')]
+		else:
+			self._steps = steps
+
+		self.scale_start = 0.0
+		self.scale_end = float(len(self._steps) - 1)
+		self.step_length = 1.0
+
+	def _get_steps(self):
+		return self._steps
+
+	steps = property(_get_steps, _set_steps)
+
+	def _get_value(self):
+		value = int(round(self.real_widget.getValue()))
+		return self._steps[value]
+
+	def _set_value(self, value):
+		try:
+			value = float(self._steps.index(value))
+		except ValueError:
+			# Invalid value, probably a value before the changes to stepslider.
+			# The values of affected step sliders used to be in [0, N], where N is the
+			# number of steps, so we use the value as index.
+			try:
+				value = self._steps[int(value)]
+			except IndexError:
+				# If that didn't work, reset the slider.
+				value = self._steps[0]
+
+		self.real_widget.setValue(value)
+
+	value = property(_get_value, _set_value)

--- a/tests/gui/menu/test_singleplayer.py
+++ b/tests/gui/menu/test_singleplayer.py
@@ -65,7 +65,7 @@ def test_start_random_map(gui):
 	gui.trigger('singleplayermenu/lbl_disasters')
 
 	gui.find('ai_players').select('3')
-	gui.find('resource_density_slider').slide(4)
+	gui.find('resource_density_slider').slide(2.0)
 
 	options = _start_game(gui)
 	assert not options.is_scenario


### PR DESCRIPTION
Externally, the slider accepts either a semicolon separated list of
steps or a list of numeric values. Reading and writing the value of the
slider works with the discrete values defined in steps.

Refs #1957 

---
### Short demo

https://www.youtube.com/watch?v=7WKlhEvzFTA
### TODO
- [x] Figure out how to handle old settings files (they stored the slider value, which on master is anything between 0 and 4, e.g. 3.4, which doesn't map to our discrete values)
