### PR TITLE
Add an attribute which stores whether a tooltip is shown or not.

### DIFF
--- a/horizons/gui/widgets/tooltip.py
+++ b/horizons/gui/widgets/tooltip.py
@@ -46,6 +46,7 @@ class _Tooltip(object):
 			self.name + '/mouseDragged/tooltip' : self.hide_tooltip
 			})
 		self.tooltip_shown = False
+		self.shown = False
 
 	def __init_gui(self):
 		self.gui = AutoResizeContainer()
@@ -97,6 +98,10 @@ class _Tooltip(object):
 			self.tooltip_shown = True
 
 	def show_tooltip(self):
+		if self.shown is True:
+			return
+		self.shown = True
+
 		if not self.helptext:
 			return
 		if self.gui is None:
@@ -116,6 +121,7 @@ class _Tooltip(object):
 		self.gui.show()
 
 	def hide_tooltip(self, event=None):
+		self.shown = False
 		if self.gui is not None:
 			self.gui.hide()
 		ExtScheduler().rem_call(self, self.show_tooltip)


### PR DESCRIPTION
This makes extra sure that no tooltip is ever shown twice. There already was an attribute doing this (self.tooltip_shown), but it does some things I don't understand and I didn't want to touch it.