### PR TITLE
Major adjustments to import_fife, find_fife and setup_fife

### DIFF
--- a/run_uh.py
+++ b/run_uh.py
@@ -282,7 +282,7 @@ def import_fife(paths):
 		try:
 			from fife import fife
 		except ImportError as e:
-			if str(e) != 'cannot import name fife':
+			if str(e) != "cannot import name 'fife'":
 				log().warning('Failed to use FIFE from %s', fife)
 				log().warning(str(e))
 				if str(e) == 'DLL load failed: %1 is not a valid Win32 application.':

--- a/run_uh.py
+++ b/run_uh.py
@@ -275,9 +275,9 @@ def setup_debugging(options):
 		log_sys_info()
 
 def find_fife(paths):
-    """Returns True if the fife module was found in one of the supplied paths."""
+	"""Returns True if the fife module was found in one of the supplied paths."""
 	try:
-        # If FIFE can't be found then this call will throw an ImportError exception:
+		# If FIFE can't be found then this call will throw an ImportError exception:
 		module_info = imp.find_module('fife', paths)
 		fife = imp.load_module('fife', *module_info)
 		try:
@@ -296,56 +296,55 @@ def find_fife(paths):
 	return True
 
 def get_fife_paths():
-    """Returns all possible paths to search for the fife module. New paths to be added as needed."""
-    # Use the path the user provided:
-    from horizons.util.cmdlineoptions import get_option_parser
-    options = get_option_parser().parse_args()[0]
-    # All paths collected in a list:
-    paths = []
-    # Check if path was provided by user:
-    if options.fife_path:
-        fife_path = os.path.abspath(options.fife_path)
-        paths.append(fife_path)
-        # Support giving the path to FIFE_ROOT/engine/python/fife/__init__.pyc etc.
-        
-        if os.path.isfile(fife_path):
-            fife_path = os.path.dirname(fife_path)
-            paths.append(fife_path)
-            # Support giving the path to FIFE_ROOT/engine/python
-            paths.append(os.path.join(fife_path, 'python'))
-            # Support giving the path to FIFE_ROOT/engine
-            paths.append(os.path.join(fife_path, 'engine', 'python'))
-            # Support giving the path to FIFE_ROOT
-            paths.append(os.path.join(fife_path, '..'))
-            # Support giving the path to FIFE_ROOT/engine/python/fife
+	"""Returns all possible paths to search for the fife module. New paths to be added as needed."""
+	# Use the path the user provided:
+	from horizons.util.cmdlineoptions import get_option_parser
+	options = get_option_parser().parse_args()[0]
+	# All paths collected in a list:
+	paths = []
+	# Check if path was provided by user:
+	if options.fife_path:
+		fife_path = os.path.abspath(options.fife_path)
+		paths.append(fife_path)
+		# Support giving the path to FIFE_ROOT/engine/python/fife/__init__.pyc etc.
 
-    # Look for FIFE in the neighborhood of the game dir:
-    for opt1 in ('.', '..', '..' + os.sep + '..'):
-        for opt2 in ('.', 'fife', 'FIFE', 'Fife', 'fifengine'):
-            for opt3 in ('.', 'trunk'):
-                path = os.path.abspath(os.path.join('.', opt1, opt2, opt3, 'engine', 'python'))
-                if os.path.exists(path):
-                    paths.append(path)
+		if os.path.isfile(fife_path):
+			fife_path = os.path.dirname(fife_path)
+			paths.append(fife_path)
+			# Support giving the path to FIFE_ROOT/engine/python
+			paths.append(os.path.join(fife_path, 'python'))
+			# Support giving the path to FIFE_ROOT/engine
+			paths.append(os.path.join(fife_path, 'engine', 'python'))
+			# Support giving the path to FIFE_ROOT
+			paths.append(os.path.join(fife_path, '..'))
+			# Support giving the path to FIFE_ROOT/engine/python/fife
 
-    # Return collected list of fife search paths:
-    return paths
+	# Look for FIFE in the neighborhood of the game dir:
+	for opt1 in ('.', '..', '..' + os.sep + '..'):
+		for opt2 in ('.', 'fife', 'FIFE', 'Fife', 'fifengine'):
+			for opt3 in ('.', 'trunk'):
+				path = os.path.abspath(os.path.join('.', opt1, opt2, opt3, 'engine', 'python'))
+				if os.path.exists(path):
+					paths.append(path)
+
+	# Return collected list of fife search paths:
+	return paths
 
 def setup_fife():
 	log_paths()
 	log_sys_info()
-    paths = get_fife_paths()
-
+	paths = get_fife_paths()
 	if not find_fife(paths):
-        try:
-            from fife import fife
-        except ImportError:
-            exit_string = ""
-            for path in paths:
-                exit_string += "{}\n"
-            exit_with_error('Failed to find and/or load FIFE', 'Below directory paths were tested:\n' + exit_string.format(*paths))
+		try:
+			from fife import fife
+		except ImportError:
+			exit_string = ""
+			for path in paths:
+				exit_string += "{}\n"
+			exit_with_error('Failed to find and/or load FIFE', 'Below directory paths were tested:\n' + exit_string.format(*paths))
 
-    # Another import call still needed?
-    from fife import fife
+	# Another import call still needed?
+	from fife import fife
 	fife_version_major = fife.getMajor() if hasattr(fife, 'getMajor') else 'unknown'
 	fife_version_minor = fife.getMinor() if hasattr(fife, 'getMinor') else 'unknown'
 	fife_version_patch = fife.getPatch() if hasattr(fife, 'getPatch') else 'unknown'

--- a/run_uh.py
+++ b/run_uh.py
@@ -333,12 +333,12 @@ def get_fife_paths():
 def setup_fife():
 	log_paths()
 	log_sys_info()
+    paths = get_fife_paths()
 
-	if not find_fife(get_fife_paths()):
+	if not find_fife(paths):
         try:
             from fife import fife
         except ImportError:
-            paths = get_fife_paths()
             exit_string = ""
             for path in paths:
                 exit_string += "{}\n"

--- a/run_uh.py
+++ b/run_uh.py
@@ -282,7 +282,7 @@ def import_fife(paths):
 		try:
 			from fife import fife
 		except ImportError as e:
-			if str(e) != "cannot import name 'fife'":
+			if str(e) != 'cannot import name fife':
 				log().warning('Failed to use FIFE from %s', fife)
 				log().warning(str(e))
 				if str(e) == 'DLL load failed: %1 is not a valid Win32 application.':

--- a/run_uh.py
+++ b/run_uh.py
@@ -297,27 +297,25 @@ def find_fife(paths):
 
 def get_fife_paths():
 	"""Returns all possible paths to search for the fife module. New paths to be added as needed."""
-	# Use the path the user provided:
+	# Use the path the user provided.
 	from horizons.util.cmdlineoptions import get_option_parser
 	options = get_option_parser().parse_args()[0]
-	# All paths collected in a list:
 	paths = []
-	# Check if path was provided by user:
+	# Check if path was provided by user.
 	if options.fife_path:
 		fife_path = os.path.abspath(options.fife_path)
 		paths.append(fife_path)
 		# Support giving the path to FIFE_ROOT/engine/python/fife/__init__.pyc etc.
-
 		if os.path.isfile(fife_path):
+			# Support giving the path to FIFE_ROOT/engine/python
 			fife_path = os.path.dirname(fife_path)
 			paths.append(fife_path)
-			# Support giving the path to FIFE_ROOT/engine/python
-			paths.append(os.path.join(fife_path, 'python'))
 			# Support giving the path to FIFE_ROOT/engine
-			paths.append(os.path.join(fife_path, 'engine', 'python'))
+			paths.append(os.path.join(fife_path, 'python'))
 			# Support giving the path to FIFE_ROOT
-			paths.append(os.path.join(fife_path, '..'))
+			paths.append(os.path.join(fife_path, 'engine', 'python'))
 			# Support giving the path to FIFE_ROOT/engine/python/fife
+			paths.append(os.path.join(fife_path, '..'))
 
 	# Look for FIFE in the neighborhood of the game dir:
 	for opt1 in ('.', '..', '..' + os.sep + '..'):
@@ -327,7 +325,6 @@ def get_fife_paths():
 				if os.path.exists(path):
 					paths.append(path)
 
-	# Return collected list of fife search paths:
 	return paths
 
 def setup_fife():
@@ -338,10 +335,8 @@ def setup_fife():
 		try:
 			from fife import fife
 		except ImportError:
-			exit_string = ""
-			for path in paths:
-				exit_string += "{}\n"
-			exit_with_error('Failed to find and/or load FIFE', 'Below directory paths were tested:\n' + exit_string.format(*paths))
+			directories = '\n'.join(paths)
+			exit_with_error('Failed to load module fife', 'Below directory paths were tested:\n' + directories)
 
 	# Another import call still needed?
 	from fife import fife


### PR DESCRIPTION
While trying to work out the TODO point in the `setup_fife()` function definition, I noticed that `import_fife()` and `find_fife()` require major adjustments. The main rationale was that `import_fife()` and `find_fife()` both return Boolean values and duplicate fife import calls. Below a brief rundown of introduced changes:

- `import_fife()` was renamed to `find_fife()`. The previous name was confusing, because the function originally only checked whether fife can be found in the provided 'paths'. Also, this is the only function that really checks whether fife exists in the specified paths. Alternatively, one could add an earlier return value when `find_fife()` finds the fife module. This can still be evaluated in if-else statements, as return None == False is true.

- `find_fife()` was renamed to `get_fife_paths()` as that's what it does anyway. Now it returns a list of paths to be later checked by find_fife(). This makes for modular and fine-grained `find_fife(get_fife_paths())` checks. Extra paths can be easily added to `get_fife_paths()` if needed.

- `setup_fife()` was changed so that the check for fife importing is local and failure is handled via try-except with a call to `exit_with_error()` if importing fails. Also, I added a pretty-print for the list of checked paths :).

- some other fixes to make the code easier to read.

I found it easier to introduce all changes as a single commit since anyhow those functions work in unison. If anything else uses them and now it's borked, I'll try to introduce fixes where needed.

Finally, now the code in `exit_with_error()` can be simplified so that the 'title' and 'message' arguments are not evaluated. That would be a separate PR, though :).