### PR TITLE
2667 imp to importlib

### DIFF
--- a/run_uh.py
+++ b/run_uh.py
@@ -279,6 +279,8 @@ def find_fife(paths):
 	"""Returns True if the fife module was found in one of the supplied paths."""
 	default_sys_path = sys.path # to restore sys.path later
 	for path in paths:
+		if path.endswith("fife"):
+			path = os.path.dirname(path)
 		sys.path.insert(0, path)
 		try:
 			import fife

--- a/run_uh.py
+++ b/run_uh.py
@@ -279,7 +279,8 @@ def find_fife(paths):
 	"""Returns True if the fife module was found in one of the supplied paths."""
 	default_sys_path = sys.path # to restore sys.path later
 	for path in paths:
-		if path.endswith("fife"):
+		# extract parent directory to FIFE module
+		if path.endswith("fife") and os.path.isdir(path):
 			path = os.path.dirname(path)
 		sys.path.insert(0, path)
 		try:

--- a/run_uh.py
+++ b/run_uh.py
@@ -285,17 +285,22 @@ def find_fife(paths):
 		sys.path.insert(0, path)
 
 		try:
-			from fife import fife
-			break
-		except ImportError as e:
+			import fife
+			try:
+				from fife import fife
+				break
+			except ImportError as e:
 				if str(e) != 'cannot import name fife':
 					log().warning('Failed to use FIFE from %s', fife)
 					log().warning(str(e))
 					if str(e) == 'DLL load failed: %1 is not a valid Win32 application.':
 						# We found FIFE but the Python and FIFE architectures don't match (Windows).
 						exit_with_error('Unsupported Python version', '32 bit FIFE requires 32 bit (x86) Python 3.')
+				return False
+		except ImportError:
+			pass
 	else:
-		sys.path = default_sys_path
+		sys.path = default_sys_path	# restore sys.path if all imports failed
 		return False
 	return True
 

--- a/run_uh.py
+++ b/run_uh.py
@@ -286,7 +286,7 @@ def find_fife(paths):
 		except ImportError:
 			pass
 	else:
-		log().warning("Module FIFE not found in supplied paths: {}.".format("\n".join(paths))
+		log().warning("Module FIFE not found in supplied paths: {}.".format("\n".join(paths)))
 
 	# restore sys.path
 	sys.path = default_sys_path
@@ -294,7 +294,7 @@ def find_fife(paths):
 	# check if fife import was registered
 	if "fife" not in sys.modules:
 		return False
-			      
+
 	try:
 		from fife import fife
 	except ImportError as e:

--- a/run_uh.py
+++ b/run_uh.py
@@ -283,30 +283,19 @@ def find_fife(paths):
 		if path.endswith("fife") and os.path.isdir(path):
 			path = os.path.dirname(path)
 		sys.path.insert(0, path)
+
 		try:
-			import fife
+			from fife import fife
 			break
-		except ImportError:
-			pass
+		except ImportError as e:
+				if str(e) != 'cannot import name fife':
+					log().warning('Failed to use FIFE from %s', fife)
+					log().warning(str(e))
+					if str(e) == 'DLL load failed: %1 is not a valid Win32 application.':
+						# We found FIFE but the Python and FIFE architectures don't match (Windows).
+						exit_with_error('Unsupported Python version', '32 bit FIFE requires 32 bit (x86) Python 3.')
 	else:
-		log().warning("Module FIFE not found in supplied paths: {}.".format("\n".join(paths)))
-
-	# restore sys.path
-	sys.path = default_sys_path
-
-	# check if fife import was registered
-	if "fife" not in sys.modules:
-		return False
-
-	try:
-		from fife import fife
-	except ImportError as e:
-		if str(e) != 'cannot import name fife':
-			log().warning('Failed to use FIFE from %s', fife)
-			log().warning(str(e))
-			if str(e) == 'DLL load failed: %1 is not a valid Win32 application.':
-				# We found FIFE but the Python and FIFE architectures don't match (Windows).
-				exit_with_error('Unsupported Python version', '32 bit FIFE requires 32 bit (x86) Python 2.')
+		sys.path = default_sys_path
 		return False
 	return True
 


### PR DESCRIPTION
Replace the deprecated `imp` module with a workaround that temporarily modifies `sys.path`. This is a simpler solution than using `importlib` (replacement for `imp`) or third-party modules.