### PR TITLE
Fix text formatting for inhabitants count/max

### DIFF
--- a/horizons/gui/tabs/residentialtabs.py
+++ b/horizons/gui/tabs/residentialtabs.py
@@ -75,7 +75,7 @@ class SettlerOverviewTab(OverviewTab):
 		self.widget.child_finder('happiness_label').image = image
 		self.widget.child_finder('happiness_label').helptext = helptext
 		self.widget.child_finder('happiness').progress = self.instance.happiness
-		self.widget.child_finder('inhabitants').text = "{}/{]".format(
+		self.widget.child_finder('inhabitants').text = "{}/{}".format(
 		                                               self.instance.inhabitants,
 		                                               self.instance.inhabitants_max)
 		self.widget.child_finder('taxes').text = str(self.instance.last_tax_payed)


### PR DESCRIPTION
Fixes crash when clicking on a tent.

> 
> Traceback (most recent call last):
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/mousetools/selectiontool.py", line 129, in mouseReleased
>     self.apply_select()
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/mousetools/selectiontool.py", line 151, in apply_select
>     next(iter(selected)).get_component(SelectableComponent).show_menu()
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/component/selectablecomponent.py", line 100, in show_menu
>     self.session.ingame_gui.show_menu(tabwidget)
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/ingamegui.py", line 311, in show_menu
>     self._old_menu.show()
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/tabwidget.py", line 146, in show
>     self._draw_widget()
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/tabwidget.py", line 139, in _draw_widget
>     self.current_tab.refresh()
>  File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/residentialtabs.py", line 80, in refresh
>     self.instance.inhabitants_max)
> ValueError: expected '}' before end of string
> 
> Unknown Horizons exited uncleanly via SIGINT
> AL lib: (EE) alc_cleanup: 1 device not closed