### PR TITLE
Fix smeltery and charcoal_burning position offsets

### DIFF
--- a/horizons/gui/tabs/barrackstabs.py
+++ b/horizons/gui/tabs/barrackstabs.py
@@ -78,7 +78,7 @@ class BarracksSelectTab(ProducerOverviewTabBase):
 		#groundunit_unbuildable = self.is_groundunit_unbuildable(groundunit)
 		groundunit_unbuildable = False
 		if not groundunit_unbuildable:
-			button = OkButton(position=(60, 50), name='ok_{}'.index(index), helptext=T('Build this groundunit!'))
+			button = OkButton(position=(60, 50), name='ok_{}'.format(index), helptext=T('Build this groundunit!'))
 			button.capture(Callback(self.start_production, prodline))
 		else:
 			button = CancelButton(position=(60, 50), name='ok_{}'.format(index),

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -101,8 +101,8 @@ class BuildingClass(IngameType):
 					params["botm"] = 66
 				# hack for charcoal_burning
 				elif cls.size[0] == 2 and cls.size[1] == 3:
-					params["left"] = 0
-					params["botm"] = 42
+					params["left"] = 25
+					params["botm"] = 55
 				elif cls.size[0] == 2:
 					params["botm"] = 40
 				elif cls.size[0] == 1:
@@ -113,7 +113,8 @@ class BuildingClass(IngameType):
 				params['left'] = 32 * cls.size[1]
 				# hack for charcoal_burning
 				if cls.size[0] == 2 and cls.size[1] == 3:
-					params["botm"] = 10
+					params["botm"] = 35
+					params["left"] = 65
 				else:
 					params['botm'] = 30
 			elif rotation == 225:
@@ -125,8 +126,8 @@ class BuildingClass(IngameType):
 					params["botm"] = 73
 				# hack for charcoal_burning
 				elif cls.size[0] == 2 and cls.size[1] == 3:
-					params["botm"] = 58
-					params["left"] = 160
+					params["botm"] = 42
+					params["left"] = 130
 				elif cls.size[0] == 2:
 					params["botm"] = 40
 				elif cls.size[0] == 1:
@@ -137,9 +138,13 @@ class BuildingClass(IngameType):
 				params['left'] = 32 * cls.size[0]
 				if cls.size[0] == 3:
 					params["botm"] = 96
-				# hack for brickyard and charcoal_burning
-				elif cls.size[0] == 2 and cls.size[1] in (3, 4):
+				# hack for brickyard
+				elif cls.size[0] == 2 and cls.size[1] == 4:
 					params["botm"] = 92
+				# hack for charcoal_burning
+				elif cls.size[0] == 2 and cls.size[1] == 3:
+					params["botm"] = 75
+					params["left"] = 100
 				elif cls.size[0] == 2:
 					params["botm"] = 56
 				elif cls.size[0] == 1:

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -96,6 +96,8 @@ class BuildingClass(IngameType):
 			params['rot'] = rotation
 			# hacks to solve issue #1379
 			if rotation == 45:
+				# default values
+				params['botm'] = 16 * cls.size[0]
 				params['left'] = 32
 				# hack for smeltery
 				if cls.size[0] == 4 and cls.size[1] == 4:
@@ -104,23 +106,23 @@ class BuildingClass(IngameType):
 					params["botm"] = 66
 				# hack for charcoal_burning
 				elif cls.size[0] == 2 and cls.size[1] == 3:
-					params["left"] = 25
 					params["botm"] = 55
+					params["left"] = 25
 				elif cls.size[0] == 2:
 					params["botm"] = 40
 				elif cls.size[0] == 1:
 					params["botm"] = 29
-				else:
-					params['botm'] = 16 * cls.size[0]
 			elif rotation == 135:
+				# default values
+				params['botm'] = 30
 				params['left'] = 32 * cls.size[1]
 				# hack for charcoal_burning
 				if cls.size[0] == 2 and cls.size[1] == 3:
 					params["botm"] = 35
 					params["left"] = 65
-				else:
-					params['botm'] = 30
 			elif rotation == 225:
+				# default values
+				params['botm'] = 16 * cls.size[1]
 				params['left'] = 32 * (cls.size[0] + cls.size[1] - 1)
 				# hack for smeltery
 				if cls.size[0] == 4 and cls.size[1] == 4:
@@ -138,10 +140,10 @@ class BuildingClass(IngameType):
 					params["botm"] = 40
 				elif cls.size[0] == 1:
 					params["botm"] = 29
-				else:
-					params['botm'] = 16 * cls.size[1]
 			elif rotation == 315:
+				# default values
 				params['left'] = 32 * cls.size[0]
+				params['botm'] = 16 * (cls.size[0] + cls.size[1] - 1)
 				# hack for smeltery
 				if cls.size[0] == 4 and cls.size[1] == 4:
 					params["botm"] = 125
@@ -159,8 +161,6 @@ class BuildingClass(IngameType):
 					params["botm"] = 56
 				elif cls.size[0] == 1:
 					params["botm"] = 30
-				else:
-					params['botm'] = 16 * (cls.size[0] + cls.size[1] - 1)
 			else:
 				assert False, "Bad rotation for action_set {id}: {rot} for action: {action}".format(**params)
 			path = '{id}+{action}+{rot}:shift:left-{left},bottom+{botm}'.format(**params)

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -97,7 +97,10 @@ class BuildingClass(IngameType):
 			# hacks to solve issue #1379
 			if rotation == 45:
 				params['left'] = 32
-				if cls.size[0] == 3:
+				# hack for smeltery
+				if cls.size[0] == 4 and cls.size[1] == 4:
+					params["botm"] = 75
+				elif cls.size[0] == 3:
 					params["botm"] = 66
 				# hack for charcoal_burning
 				elif cls.size[0] == 2 and cls.size[1] == 3:
@@ -119,7 +122,10 @@ class BuildingClass(IngameType):
 					params['botm'] = 30
 			elif rotation == 225:
 				params['left'] = 32 * (cls.size[0] + cls.size[1] - 1)
-				if cls.size[0] == 3:
+				# hack for smeltery
+				if cls.size[0] == 4 and cls.size[1] == 4:
+					params["botm"] = 75
+				elif cls.size[0] == 3:
 					params["botm"] = 60
 				# hack for brickyard
 				elif cls.size[0] == 2 and cls.size[1] == 4:
@@ -136,7 +142,11 @@ class BuildingClass(IngameType):
 					params['botm'] = 16 * cls.size[1]
 			elif rotation == 315:
 				params['left'] = 32 * cls.size[0]
-				if cls.size[0] == 3:
+				# hack for smeltery
+				if cls.size[0] == 4 and cls.size[1] == 4:
+					params["botm"] = 125
+					params["left"] = 135
+				elif cls.size[0] == 3:
 					params["botm"] = 96
 				# hack for brickyard
 				elif cls.size[0] == 2 and cls.size[1] == 4:


### PR DESCRIPTION
I added extra *hacks* for the smeltery and charcoal burner buildings. Now they are properly positioned. Although this resolves issue #1379, I feel our offset system is inherently broken and any semi-manual x , y adjustments barely compensate for that.