### PR TITLE
constants.py: set encoding

### DIFF
--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 # ###################################################
 # Copyright (C) 2008-2017 The Unknown Horizons Team
 # team@unknown-horizons.org


### PR DESCRIPTION

`setup.py` caused the following errors.
```
Traceback (most recent call last):
  File "setup.py", line 34, in <module>
    from horizons.constants import VERSION
  File "/private/tmp/unknown-horizons-20171024-84852-cz9n25/horizons/constants.py", line 691
SyntaxError: Non-ASCII character '\xd8' in file /private/tmp/unknown-horizons-20171024-84852-cz9n25/horizons/constants.py on line 691, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

In http://python.org/dev/peps/pep-0263/
>Python will default to ASCII as standard encoding if no other encoding hints are given.