### PR TITLE
Avoid double-firing of `keyPressed` events

### DIFF
--- a/horizons/gui/keylisteners/ingamekeylistener.py
+++ b/horizons/gui/keylisteners/ingamekeylistener.py
@@ -35,6 +35,7 @@ class IngameKeyListener(fife.IKeyListener, LivingObject):
 		from horizons.session import Session
 		assert isinstance(session, Session)
 		self.session = session
+		self.keyconfig = KeyConfig()
 		horizons.globals.fife.eventmanager.addKeyListenerFront(self)
 		# Used to sum up the keyboard autoscrolling
 		self.key_scroll = [0, 0]
@@ -43,6 +44,8 @@ class IngameKeyListener(fife.IKeyListener, LivingObject):
 		self.left_key_pressed = False
 		self.right_key_pressed = False
 		self.key_scroll_speed = 25
+		# Last event (to avoid double-firing)
+		self.last_evt = {'type': None, 'value': None}
 
 	def end(self):
 		horizons.globals.fife.eventmanager.removeKeyListener(self)
@@ -64,7 +67,7 @@ class IngameKeyListener(fife.IKeyListener, LivingObject):
 
 	def keyPressed(self, evt):
 		keyval = evt.getKey().getValue()
-		action = KeyConfig().translate(evt)
+		action = self.keyconfig.translate(evt)
 
 		_Actions = KeyConfig._Actions
 
@@ -79,13 +82,23 @@ class IngameKeyListener(fife.IKeyListener, LivingObject):
 
 		self.updateAutoscroll()
 
+		# if the current event is identical to the previous one, ignore it
+		if (evt.getType() == self.last_evt['type'] and
+				evt.getKey().getValue() == self.last_evt['value']):
+			evt.consume() # prevent other listeners from being called
+			return
+
 		if self.session.ingame_gui.on_key_press(action, evt):
 			evt.consume() # prevent other listeners from being called
+
+		# update last event
+		self.last_evt['type'] = evt.getType()
+		self.last_evt['value'] = evt.getKey().getValue()
 
 	def keyReleased(self, evt):
 		keyval = evt.getKey().getValue()
 		_Actions = KeyConfig._Actions
-		action = KeyConfig().translate(evt)
+		action = self.keyconfig.translate(evt)
 
 		if action == _Actions.UP:
 			self.up_key_pressed = False
@@ -97,3 +110,7 @@ class IngameKeyListener(fife.IKeyListener, LivingObject):
 			self.right_key_pressed = False
 
 		self.updateAutoscroll()
+
+		# update last event
+		self.last_evt['type'] = evt.getType()
+		self.last_evt['value'] = evt.getKey().getValue()


### PR DESCRIPTION
The `IngameKeyListener` seems to double fire `keyPressed` events.
The net effect is that it is impossible to use hotkeys such as 'B'
because the dropdown construction menu just flashes for an instant
and then closes back down immediately.

I suspect this is a deeper issue inside `fifengine`, but I am not
familiar with that so here I offer a quick fix to avoid the problem.

Simply put, the `IngameKeyListener` keeps track of the last event
and, if the current one is identical (same key, same press/release
status), it directly discards it without further processing.

Furthermore, I also cache an instance of `KeyConfig` inside
`IngameKeyListener` instead of instantiating one every time
`keyPressed` or `keyReleased` are called. This just popped to my eyes
as an obvious optimization to implement, but feel free to discard if
it gives raise to some problems.