### PR TITLE
Add in fixme tests

### DIFF
--- a/horizons/main.py
+++ b/horizons/main.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 """
 Following are a list of global variables. Their scope is this module.
 Since this is not a class, in each function where these variables are
-referenced, they need to be declared with 'global' keyword. 
+referenced, they need to be declared with 'global' keyword.
 
 See: http://python-textbok.readthedocs.io/en/1.0/Variables_and_Scope.html
 """
@@ -596,7 +596,7 @@ def set_debug_log(enabled, startup=False):
 	@param startup: True if on startup to apply settings. Won't show popup
 	"""
 	global gui, command_line_arguments
- 
+
 	options = command_line_arguments
 
 	if enabled: # enable logging

--- a/horizons/view.py
+++ b/horizons/view.py
@@ -73,7 +73,7 @@ class View(ChangeListener):
 
 		rect = fife.Rect(0, 0, horizons.globals.fife.engine_settings.getScreenWidth(),
 		                       horizons.globals.fife.engine_settings.getScreenHeight())
-		self.cam = self.map.addCamera("main", rect)
+		self.cam = self.map.addCamera("main", self.layers[-1], rect)
 		self.cam.setCellImageDimensions(*VIEW.CELL_IMAGE_DIMENSIONS)
 		self.cam.setRotation(VIEW.ROTATION)
 		self.cam.setTilt(VIEW.TILT)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ select = W2, W3, W6, E11, E125, E13, E211, E223, E224, E225, E226, E227, E228, E
 # https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 ignore = E101, W191, W503, E241
 max-line-length = 100
+[pytest]
+addopts = --runxfail
+#--runxfail runs tests even if expected to fail.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,12 @@ import pytest
 def pytest_addoption(parser):
 	parser.addoption('--long-tests', action='store_true', help='include long-running tests')
 	parser.addoption('--gui-tests', action='store_true', help='include gui tests')
+	parser.addoption('--fixme-fail-tests', action='store_true', help='fail on fixme')
 
 
 def pytest_configure(config):
 	config.addinivalue_line('markers', 'long: mark test as long-running')
+	config.addinivalue_line('markers', 'fixme: mark test as known-broken')
 
 
 def pytest_runtest_setup(item):
@@ -49,6 +51,10 @@ def pytest_runtest_setup(item):
 	marker = item.get_marker('gui_test')
 	if marker is not None and not item.config.getoption('--gui-tests'):
 		pytest.skip('test is gui test')
+
+	marker = item.get_marker("fixme")
+	if marker is not None and not item.config.getoption('--fixme-fail-tests'):
+		pytest.xfail("Expecting failure")
 
 
 # Basic test setup, installs global mock for fife so we can run gui/game tests.

--- a/tests/game/test_buildings.py
+++ b/tests/game/test_buildings.py
@@ -636,7 +636,7 @@ def test_weaponsmith_production_chain(s, p):
 	assert weaponsmith.get_component(StorageComponent).inventory[RES.SWORD]
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.fixme()
 @game_test()
 def test_barracks_production_chain(s, p):
 	"""

--- a/tests/game/test_traderoute.py
+++ b/tests/game/test_traderoute.py
@@ -27,7 +27,7 @@ from horizons.constants import RES
 from tests.game import game_test
 
 
-@pytest.mark.xfail(strict=True)
+@pytest.mark.fixme()
 @game_test(use_fixture='traderoute')
 def test_traderoute_basic(s):
 	"""

--- a/tests/gui/ingame/test_boatbuilder.py
+++ b/tests/gui/ingame/test_boatbuilder.py
@@ -24,7 +24,9 @@ from horizons.world.production.producer import Producer
 from tests.gui import gui_test
 from tests.gui.helper import saveload
 
+import pytest
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1224(gui):
 	"""
@@ -59,6 +61,7 @@ def test_ticket_1224(gui):
 	assert running_costs() == '25', "Expected 25, got {}".format(running_costs())
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1294(gui):
 	"""
@@ -98,6 +101,7 @@ def test_ticket_1294(gui):
 		gui.run()
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1830(gui):
 	"""
@@ -135,6 +139,7 @@ def test_ticket_1830(gui):
 	assert len(producer.production_queue) == 1
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=60)
 def test_remove_from_queue(gui):
 	"""
@@ -160,6 +165,7 @@ def test_remove_from_queue(gui):
 	gui.trigger('UB_main_tab/queue_elem_0')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=60)
 def test_cancel_ticket_1424(gui):
 	"""
@@ -187,6 +193,7 @@ def test_cancel_ticket_1424(gui):
 	gui.trigger('UB_main_tab/UB_cancel_button')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=60)
 def test_save_load_ticket_1421(gui):
 	"""
@@ -212,6 +219,7 @@ def test_save_load_ticket_1421(gui):
 	saveload(gui)
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1513(gui):
 	"""
@@ -254,6 +262,7 @@ def test_ticket_1513(gui):
 	assert running_costs() == '10', "Expected 10, got {}".format(running_costs())
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1514(gui):
 	"""

--- a/tests/gui/ingame/test_boatbuilder.py
+++ b/tests/gui/ingame/test_boatbuilder.py
@@ -19,12 +19,13 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from horizons.constants import BUILDINGS, PRODUCTION, UNITS
 from horizons.world.production.producer import Producer
 from tests.gui import gui_test
 from tests.gui.helper import saveload
 
-import pytest
 
 @pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)

--- a/tests/gui/ingame/test_bugs.py
+++ b/tests/gui/ingame/test_bugs.py
@@ -28,7 +28,9 @@ from horizons.world.production.producer import Producer
 from tests.gui import gui_test
 from tests.gui.helper import found_settlement, get_player_ship, move_ship
 
+import pytest
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)
 def test_ticket_1352(gui):
 	"""
@@ -51,6 +53,7 @@ def test_ticket_1352(gui):
 	gui.select([ship])
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, ai_players=3, timeout=120)
 def test_ticket_1368(gui):
 	"""
@@ -70,6 +73,7 @@ def test_ticket_1368(gui):
 	gui.select([ai_warehouse])
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='ai_settlement', timeout=60)
 def test_ticket_1369(gui):
 	"""
@@ -106,6 +110,7 @@ def test_ticket_1369(gui):
 #	assert gui.find(name='overview_trade_ship')
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)
 def test_ticket_1362(gui):
 	"""
@@ -128,6 +133,7 @@ def test_ticket_1362(gui):
 		gui.press_key(gui.Key.F5)
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain', timeout=120)
 def test_ticket_1371(gui):
 	"""
@@ -170,6 +176,7 @@ def test_ticket_1371(gui):
 	assert gui.find(name='overview_buildrelated')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='fife_exception_not_found', timeout=60)
 def test_ticket_1447(gui):
 	"""
@@ -195,6 +202,7 @@ def test_ticket_1447(gui):
 	gui.run()
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)
 def test_ticket_1515(gui):
 	"""
@@ -204,6 +212,7 @@ def test_ticket_1515(gui):
 	gui.cursor_click(6, 17, 'left')
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)
 def test_ticket_1520(gui):
 	"""
@@ -233,6 +242,7 @@ def test_ticket_1520(gui):
 	gui.cursor_release_button(13, 11, 'left')
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)
 def test_ticket_1509(gui):
 	"""
@@ -257,6 +267,7 @@ def test_ticket_1509(gui):
 	gui.trigger('tab_base/1')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1526(gui):
 	"""
@@ -272,6 +283,7 @@ def test_ticket_1526(gui):
 	gui.cursor_click(52, 12, 'left', ctrl=True)
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain', timeout=120)
 def test_pavilion_build_crash_built_via_settler_related_tab(gui):
 	"""
@@ -299,6 +311,7 @@ def test_pavilion_build_crash_built_via_settler_related_tab(gui):
 	# if we survive until here, the bug hasn't happened
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=120)
 def test_ticket_1848(gui):
 	"""Settlement production overview crashes if ships were produced"""
@@ -320,6 +333,7 @@ def test_ticket_1848(gui):
 	gui.trigger('tab_account/show_production_overview')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain')
 def test_ticket_1948(gui):
 	"""Triggers a crash that happens when building a storage tent on the border of the settlement"""
@@ -336,6 +350,7 @@ def test_ticket_1948(gui):
 	gui.cursor_click(37, 20, 'left')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='fife_exception_not_found', timeout=60)
 def test_ticket_2117(gui):
 	"""Changing language with active production overview tab crashes game"""
@@ -353,6 +368,7 @@ def test_ticket_2117(gui):
 	gui.trigger('settings_window/okButton')
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_ticket_2419(gui):
 	"""Game crashes when setting speed to zero and pressing pause twice"""
@@ -362,6 +378,7 @@ def test_ticket_2419(gui):
 	gui.press_key(gui.Key.P)
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_ticket_2475(gui):
 	"""Game crashes when two resources are produced in the same tick and the production
@@ -389,6 +406,7 @@ def test_ticket_2475(gui):
 	producer.on_production_finished({RES.BOARDS: 1})
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_ticket_2500(gui):
 	"""Game crashes when exiting the game while the building tool is still active."""

--- a/tests/gui/ingame/test_bugs.py
+++ b/tests/gui/ingame/test_bugs.py
@@ -19,6 +19,8 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from horizons.command.building import Tear
 from horizons.command.unit import CreateUnit
 from horizons.component.storagecomponent import StorageComponent
@@ -28,7 +30,6 @@ from horizons.world.production.producer import Producer
 from tests.gui import gui_test
 from tests.gui.helper import found_settlement, get_player_ship, move_ship
 
-import pytest
 
 @pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)

--- a/tests/gui/ingame/test_build.py
+++ b/tests/gui/ingame/test_build.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import time
+import pytest
 
 from horizons.component.collectingcomponent import CollectingComponent
 from horizons.constants import BUILDINGS
@@ -28,6 +29,7 @@ from tests.gui import gui_test
 from tests.gui.helper import found_settlement
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain', timeout=60)
 def test_found_settlement(gui):
 	"""

--- a/tests/gui/ingame/test_build.py
+++ b/tests/gui/ingame/test_build.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import time
+
 import pytest
 
 from horizons.component.collectingcomponent import CollectingComponent

--- a/tests/gui/ingame/test_dialogs.py
+++ b/tests/gui/ingame/test_dialogs.py
@@ -19,11 +19,14 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from horizons.component.namedcomponent import NamedComponent
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_change_name(gui):
 	"""Rename a ship."""
@@ -48,6 +51,7 @@ def test_change_name(gui):
 	assert new_name == 'Dagobert'
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_change_name_empty_not_allowed(gui):
 	"""Make sure an object's name can't be changed to some empty string.
@@ -82,6 +86,7 @@ def test_change_name_empty_not_allowed(gui):
 	assert old_name == new_name
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_chat(gui):
 	"""Opens chat dialog.

--- a/tests/gui/ingame/test_diplomacy.py
+++ b/tests/gui/ingame/test_diplomacy.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import pytest
+
 from tests.gui import gui_test
 
 

--- a/tests/gui/ingame/test_diplomacy.py
+++ b/tests/gui/ingame/test_diplomacy.py
@@ -19,9 +19,11 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
 from tests.gui import gui_test
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, ai_players=1)
 def test_diplomacy(gui):
 	"""Test changing diplomacy status."""

--- a/tests/gui/ingame/test_generated.py
+++ b/tests/gui/ingame/test_generated.py
@@ -20,11 +20,13 @@
 # ###################################################
 
 import itertools
+import pytest
 
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain', timeout=120)
 def test_build_a_settlement(gui):
 	"""
@@ -104,6 +106,7 @@ def test_build_a_settlement(gui):
 	gui.cursor_click(58, 5, 'left')
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain', timeout=120)
 def test_buildingtool(gui):
 	"""

--- a/tests/gui/ingame/test_generated.py
+++ b/tests/gui/ingame/test_generated.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import itertools
+
 import pytest
 
 from tests.gui import gui_test

--- a/tests/gui/ingame/test_hud.py
+++ b/tests/gui/ingame/test_hud.py
@@ -19,9 +19,11 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
 from tests.gui import gui_test
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_hud(gui):
 	"""

--- a/tests/gui/ingame/test_hud.py
+++ b/tests/gui/ingame/test_hud.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import pytest
+
 from tests.gui import gui_test
 
 

--- a/tests/gui/ingame/test_keys.py
+++ b/tests/gui/ingame/test_keys.py
@@ -20,8 +20,9 @@
 # ###################################################
 
 from tests.gui import gui_test
+import pytest
 
-
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)
 def test_ticket_1342(gui):
 	"""

--- a/tests/gui/ingame/test_keys.py
+++ b/tests/gui/ingame/test_keys.py
@@ -19,8 +19,10 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-from tests.gui import gui_test
 import pytest
+
+from tests.gui import gui_test
+
 
 @pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=120)

--- a/tests/gui/ingame/test_logbook.py
+++ b/tests/gui/ingame/test_logbook.py
@@ -19,9 +19,10 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from tests.gui import gui_test
 
-import pytest
 
 @pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)

--- a/tests/gui/ingame/test_logbook.py
+++ b/tests/gui/ingame/test_logbook.py
@@ -21,7 +21,9 @@
 
 from tests.gui import gui_test
 
+import pytest
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_logbook(gui):
 	"""
@@ -38,6 +40,7 @@ def test_logbook(gui):
 	assert gui.find(name='captains_log') is None
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=60)
 def test_logbook_statistics(gui):
 	"""Open the 3 three different statistic tabs in the logbook."""

--- a/tests/gui/ingame/test_selection.py
+++ b/tests/gui/ingame/test_selection.py
@@ -19,12 +19,13 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from horizons.command.unit import CreateUnit
 from horizons.constants import UNITS
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship
 
-import pytest
 
 @pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)

--- a/tests/gui/ingame/test_selection.py
+++ b/tests/gui/ingame/test_selection.py
@@ -24,7 +24,9 @@ from horizons.constants import UNITS
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship
 
+import pytest
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_select_ship(gui):
 	"""
@@ -43,6 +45,7 @@ def test_select_ship(gui):
 	assert gui.find('overview_trade_ship')
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_selectmultitab(gui):
 	"""
@@ -75,6 +78,7 @@ def test_selectmultitab(gui):
 	gui.run(seconds=0.1)
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='plain', timeout=120)
 def test_selection_groups(gui):
 	"""Check group selection using ctrl-NUM"""

--- a/tests/gui/ingame/test_traderoute.py
+++ b/tests/gui/ingame/test_traderoute.py
@@ -19,6 +19,8 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from unittest.mock import Mock
 
 from fife import fife
@@ -30,6 +32,7 @@ from tests.gui import gui_test
 from tests.gui.helper import found_settlement, get_player_ship
 
 
+@pytest.mark.fixme()
 @gui_test(additional_cmdline=['--start-map', 'mp-dev'])
 def test_traderoute(gui):
 	"""Check that a ship's route is configured correctly after setting it up using the GUI."""

--- a/tests/gui/ingame/test_traderoute.py
+++ b/tests/gui/ingame/test_traderoute.py
@@ -19,10 +19,9 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-import pytest
-
 from unittest.mock import Mock
 
+import pytest
 from fife import fife
 
 from horizons.constants import RES

--- a/tests/gui/ingame/test_warehouse.py
+++ b/tests/gui/ingame/test_warehouse.py
@@ -19,9 +19,12 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from tests.gui import gui_test
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder', timeout=60)
 def test_production_overview(gui):
 

--- a/tests/gui/ingame/test_windows.py
+++ b/tests/gui/ingame/test_windows.py
@@ -19,11 +19,14 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
+
 from tests.gui import gui_test
 from tests.utils import mark_flaky
 
 
 @mark_flaky
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, timeout=60)
 def test_settings_dialog_crash(gui):
 	"""Opening&closing the settings dialog in two different games crashes."""
@@ -56,6 +59,7 @@ def test_settings_dialog_crash(gui):
 	gui.trigger('settings_window/okButton')  # this crashes
 
 
+@pytest.mark.fixme()
 @gui_test(timeout=60)
 def test_settings_dialog_crash2(gui):
 	# open settings in main menu

--- a/tests/gui/menu/test_saveload.py
+++ b/tests/gui/menu/test_saveload.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import os
+import pytest
 import shutil
 from unittest import mock
 
@@ -66,7 +67,7 @@ def test_load_game_no_savegames(gui):
 	with gui.handler(func1):
 		gui.trigger('menu/load_button')
 
-
+@pytest.mark.fixme()
 @gui_test(timeout=60, use_dev_map=True, cleanup_userdir=True)
 def test_save_game_new_file(gui):
 	"""Test saving a game."""
@@ -85,6 +86,7 @@ def test_save_game_new_file(gui):
 	assert os.path.exists(SavegameManager.create_filename('testsave'))
 
 
+@pytest.mark.fixme()
 @gui_test(timeout=60, use_dev_map=True, cleanup_userdir=True)
 def test_save_game_override(gui):
 	"""Test saving a game."""

--- a/tests/gui/menu/test_saveload.py
+++ b/tests/gui/menu/test_saveload.py
@@ -20,9 +20,10 @@
 # ###################################################
 
 import os
-import pytest
 import shutil
 from unittest import mock
+
+import pytest
 
 from horizons.savegamemanager import SavegameManager
 from tests.gui import TEST_FIXTURES_DIR, gui_test

--- a/tests/gui/menu/test_saveload.py
+++ b/tests/gui/menu/test_saveload.py
@@ -68,6 +68,7 @@ def test_load_game_no_savegames(gui):
 	with gui.handler(func1):
 		gui.trigger('menu/load_button')
 
+
 @pytest.mark.fixme()
 @gui_test(timeout=60, use_dev_map=True, cleanup_userdir=True)
 def test_save_game_new_file(gui):

--- a/tests/gui/scenarios/test_simple.py
+++ b/tests/gui/scenarios/test_simple.py
@@ -19,7 +19,8 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-import pytest 
+import pytest
+
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship, move_ship
 from tests.gui.scenarios.helper import assert_defeat, assert_goal_reached, assert_win

--- a/tests/gui/scenarios/test_simple.py
+++ b/tests/gui/scenarios/test_simple.py
@@ -19,7 +19,7 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
-
+import pytest 
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship, move_ship
 from tests.gui.scenarios.helper import assert_defeat, assert_goal_reached, assert_win
@@ -27,6 +27,7 @@ from tests.gui.scenarios.helper import assert_defeat, assert_goal_reached, asser
 # Example tests
 
 
+@pytest.mark.fixme()
 @gui_test(use_scenario='tests/gui/scenarios/win', timeout=20)
 def test_win(gui):
 	"""Simple test that detects a win in a game."""
@@ -34,6 +35,7 @@ def test_win(gui):
 	assert_win(gui)
 
 
+@pytest.mark.fixme()
 @gui_test(use_scenario='tests/gui/scenarios/defeat', timeout=20)
 def test_defeat(gui):
 	"""Simple test that detects a defeat in a game."""
@@ -41,6 +43,7 @@ def test_defeat(gui):
 	assert_defeat(gui)
 
 
+@pytest.mark.fixme()
 @gui_test(use_scenario='tests/gui/scenarios/mission1', timeout=40)
 def test_mission1(gui):
 	"""Sample mission which requires multiple buildings to win."""

--- a/tests/gui/scenarios/test_tutorial.py
+++ b/tests/gui/scenarios/test_tutorial.py
@@ -19,6 +19,7 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
 from horizons.constants import RES, TIER
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship, move_ship, saveload
@@ -26,6 +27,7 @@ from tests.gui.scenarios.helper import (
 	assert_win, settlement_res_stored_greater, settler_level_greater, var_eq, wait_and_close_logbook)
 
 
+@pytest.mark.fixme()
 @gui_test(use_scenario='content/scenarios/tutorial_en', timeout=7 * 60)
 def test_tutorial(gui):
 	"""Test the tutorial scenario."""

--- a/tests/gui/scenarios/test_tutorial.py
+++ b/tests/gui/scenarios/test_tutorial.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import pytest
+
 from horizons.constants import RES, TIER
 from tests.gui import gui_test
 from tests.gui.helper import get_player_ship, move_ship, saveload

--- a/tests/gui/test_editor.py
+++ b/tests/gui/test_editor.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import os
+import pytest
 
 from horizons.constants import EDITOR, GROUND, PATHS
 from tests.gui import gui_test
@@ -28,6 +29,7 @@ from tests.utils import mark_flaky
 editor_test = gui_test(additional_cmdline=["--edit-map", "development"])
 
 
+@pytest.mark.fixme()
 @editor_test
 def test_place_tiles(gui):
 	"""Place different tiles with different tile sizes."""
@@ -50,6 +52,7 @@ def test_place_tiles(gui):
 	gui.cursor_click(-8, 78, 'left')
 
 
+@pytest.mark.fixme()
 @editor_test
 def test_save_map(gui):
 	"""Save a map in the editor."""
@@ -68,6 +71,7 @@ def test_save_map(gui):
 	assert os.path.exists(os.path.join(PATHS.USER_MAPS_DIR, "test_map.sqlite"))
 
 
+@pytest.mark.fixme()
 @editor_test
 def test_drag_mouse(gui):
 	"""Test that tiles are placed while dragging the mouse."""

--- a/tests/gui/test_editor.py
+++ b/tests/gui/test_editor.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import os
+
 import pytest
 
 from horizons.constants import EDITOR, GROUND, PATHS

--- a/tests/gui/test_example.py
+++ b/tests/gui/test_example.py
@@ -19,6 +19,7 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
 from tests.gui import gui_test
 
 
@@ -32,6 +33,7 @@ from tests.gui import gui_test
 # 	ai_players=1			- Game launches with --ai-players=1
 # 	timeout=3				- Game will be killed after 3 seconds
 #
+@pytest.mark.fixme()
 @gui_test(timeout=60)
 def test_example(gui):
 	"""

--- a/tests/gui/test_example.py
+++ b/tests/gui/test_example.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import pytest
+
 from tests.gui import gui_test
 
 

--- a/tests/gui/test_internal.py
+++ b/tests/gui/test_internal.py
@@ -28,18 +28,21 @@ from horizons.scheduler import Scheduler
 from tests.gui import gui_test
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_trivial(gui):
 	"""Does nothing to see if test setup works."""
 	pass
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True, _user_dir=os.path.join("test_settings", ".unknown-horizons"))
 def test_update_settings(gui):
 	"""Does nothing to see if the settings update works."""
 	pass
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_run_for_x_seconds(gui):
 	"""Test that running the game X seconds works."""
@@ -54,6 +57,7 @@ def test_run_for_x_seconds(gui):
 	assert deviation < 0.05, 'Expected max 0.05 deviation, got {}'.format(deviation)
 
 
+@pytest.mark.fixme()
 @gui_test(use_fixture='boatbuilder')
 def test_trigger(gui):
 	"""Test the different ways to trigger an action in a gui."""
@@ -96,6 +100,7 @@ def test_trigger(gui):
 	assert not gui.find('production_overview')
 
 
+@pytest.mark.fixme()
 @gui_test(timeout=60)
 def test_dialog(gui):
 	"""Test handling of a dialog."""
@@ -111,6 +116,7 @@ def test_dialog(gui):
 
 
 @pytest.mark.xfail(strict=True)
+@pytest.mark.fixme()
 @gui_test(timeout=60)
 def test_failing(gui):
 	"""

--- a/tests/gui/test_mousetools.py
+++ b/tests/gui/test_mousetools.py
@@ -20,6 +20,7 @@
 # ###################################################
 
 import pytest
+
 from tests.gui import gui_test
 from tests.gui.helper import found_settlement
 

--- a/tests/gui/test_mousetools.py
+++ b/tests/gui/test_mousetools.py
@@ -19,10 +19,12 @@
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # ###################################################
 
+import pytest
 from tests.gui import gui_test
 from tests.gui.helper import found_settlement
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_tearing(gui):
 	found_settlement(gui, (11, 1), (11, 6))
@@ -42,6 +44,7 @@ def test_tearing(gui):
 	gui.cursor_drag((5, 15), (15, 3), 'left')
 
 
+@pytest.mark.fixme()
 @gui_test(use_dev_map=True)
 def test_pipette(gui):
 	found_settlement(gui, (11, 1), (11, 6))

--- a/tests/gui/test_unicode.py
+++ b/tests/gui/test_unicode.py
@@ -28,6 +28,7 @@ def modify_user_dir(path):
 	return path.join('H߀ｒìｚｏԉｓ')
 
 
+@pytest.mark.fixme()
 @gui_test(timeout=60, use_dev_map=True, _modify_user_dir=modify_user_dir)
 def test_user_dir_contains_non_ascii(gui):
 	"""This test will end the game immediately."""


### PR DESCRIPTION
A better approach than simply skipping all the known-broken tests.
This adds a pytest mark 'fixme', and flags all currently broken tests with it.