### PR TITLE
Fix tooltip position when close to edge of screen (#2717)

### DIFF
--- a/horizons/gui/widgets/tooltip.py
+++ b/horizons/gui/widgets/tooltip.py
@@ -107,6 +107,11 @@ class _Tooltip:
 		if top_pos == (0, 0):
 			return
 
+		if not self.tooltip_shown:
+			self.show_tooltip()
+			#ExtScheduler().add_new_object(self.show_tooltip, self, run_in=0.3, loops=0)
+			self.tooltip_shown = True
+
 		screen_width = horizons.globals.fife.engine_settings.getScreenWidth()
 		self.gui.y = widget_position[1] + y + 5
 		offset = x + 10
@@ -114,10 +119,6 @@ class _Tooltip:
 			# right screen edge, position to the left of cursor instead
 			offset = x - self.gui.size[0] - 5
 		self.gui.x = widget_position[0] + offset
-		if not self.tooltip_shown:
-			self.show_tooltip()
-			#ExtScheduler().add_new_object(self.show_tooltip, self, run_in=0.3, loops=0)
-			self.tooltip_shown = True
 
 	def show_tooltip(self):
 		if not self.helptext:


### PR DESCRIPTION
When the tooltip would be partially off-screen it is now shown on the left side of the cursor

This is done by first calling show_tooltip (which will set the tooltips size) and then checking the size (instead of the other way around)