### PR TITLE
show minimap with same rotation as map

### DIFF
--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -698,7 +698,7 @@ class Minimap:
 			self.draw()
 
 	def _get_rotation(self):
-		return self.rotation * math.pi / 2
+		return (-self.rotation - 0.5) * math.pi / 2
 
 	def _get_rotated_coords(self, tup):
 		"""Rotates according to current rotation settings.

--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -557,8 +557,7 @@ class Minimap:
 		for (x, y), color in iter_minimap_points(self.location, self.world,
 						self.COLORS["island"], self.COLORS["water"], where):
 			if use_rotation:
-				# inlined _get_rotated_coords
-				rot_x, rot_y = self._rotate((location_left + x, location_top + y), self._rotations)
+				rot_x, rot_y = self._get_rotated_coords((location_left + x, location_top + y))
 				fife_point.set(rot_x - location_left, rot_y - location_top)
 			else:
 				fife_point.set(x, y)
@@ -698,28 +697,18 @@ class Minimap:
 			self._rotation_setting = message.new_value
 			self.draw()
 
-	_rotations = { 0 : 0,
-				         1 : 3 * math.pi / 2,
-				         2 : math.pi,
-				         3 : math.pi / 2
-				         }
+	def _get_rotation(self):
+		return self.rotation * math.pi / 2
 
 	def _get_rotated_coords(self, tup):
 		"""Rotates according to current rotation settings.
 		Input coord must be relative to screen origin, not minimap origin"""
-		return self._rotate(tup, self._rotations)
-
-	_from_rotations = { 0 : 0,
-				              1 : math.pi / 2,
-				              2 : math.pi,
-				              3 : 3 * math.pi / 2
-				              }
+		return self._rotate(tup, self._get_rotation())
 
 	def _get_from_rotated_coords(self, tup):
-		return self._rotate(tup, self._from_rotations)
+		return self._rotate(tup, self._get_rotation())
 
-	def _rotate(self, tup, rotations):
-		rotation = rotations[self.rotation]
+	def _rotate(self, tup, rotation):
 
 		x = tup[0]
 		y = tup[1]

--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -297,20 +297,8 @@ class Minimap:
 		# draw rect for current screen
 		displayed_area = self.view.get_displayed_area()
 		minimap_corners_as_point = []
-		for corner in displayed_area.get_corners():
-			# check if the corners are outside of the screen
-			corner = list(corner)
-			if corner[0] > self.world.max_x:
-				corner[0] = self.world.max_x
-			if corner[0] < self.world.min_x:
-				corner[0] = self.world.min_x
-			if corner[1] > self.world.max_y:
-				corner[1] = self.world.max_y
-			if corner[1] < self.world.min_y:
-				corner[1] = self.world.min_y
-			corner = tuple(corner)
-
-			coords = self._world_to_minimap(corner, use_rotation)
+		for (x, y) in displayed_area:
+			coords = self._world_to_minimap((x, y), use_rotation)
 			minimap_corners_as_point.append(fife.Point(coords[0], coords[1]))
 
 		for i in range(0, 4):

--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -533,11 +533,12 @@ class Minimap:
 		draw_point = rt.addPoint
 
 		fife_point = fife.Point(0, 0)
-		full_map = self.world.full_map
 		island_color = self.COLORS["island"]
 		water_color = self.COLORS["water"]
+		full_map = self.world.full_map
 
-		for (x, y) in self.transform.iter_points(where):
+		for (x, y) in self.iter_points(where):
+
 			real_map_coords = self._minimap_to_world((x, y))
 
 			# check what's at the covered_area
@@ -775,7 +776,7 @@ class _MinimapTransform:
 		location = self.location
 
 		if area is None:
-			area = self.location
+			area = location
 
 		# loop through map coordinates, assuming (0, 0) is the origin of the minimap
 		# this facilitates calculating the real world coords

--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -662,8 +662,6 @@ class Minimap:
 		x_ = x * self._cos_rotation - y * self._sin_rotation
 		y_ = x * self._sin_rotation + y * self._cos_rotation
 
-		# TODO: account for change in width and height after rotation
-
 		# scale to minimap size and translate to correct position
 		x = x_ * self._world_minimap_ratio_x + self.location.center.x
 		y = y_ * self._world_minimap_ratio_y + self.location.center.y
@@ -697,8 +695,10 @@ class Minimap:
 		self._sin_rotation = sin(self._rotation_rad)
 		self._cos_rotation = cos(self._rotation_rad)
 
-		self._world_minimap_ratio_x = self.location.width / self.world.map_dimensions.width
-		self._world_minimap_ratio_y = self.location.height / self.world.map_dimensions.height
+		self._scale_correction = max(abs(self._sin_rotation), abs(self._cos_rotation))
+
+		self._world_minimap_ratio_x = self.location.width / self.world.map_dimensions.width * self._scale_correction
+		self._world_minimap_ratio_y = self.location.height / self.world.map_dimensions.height * self._scale_correction
 
 
 	def _get_rotation_setting(self):


### PR DESCRIPTION
Since the map is isometric the minimap rotation was always (at least) 45 degrees off.

These changes solve that

Also, the minimap class has been majorly refactored, pulling most of the transformation code in its own class.