### PR TITLE
Make MinimapRotation default to True

### DIFF
--- a/content/settings-template.xml
+++ b/content/settings-template.xml
@@ -43,7 +43,7 @@
 		<Setting name="ClientID" type="str"></Setting>
 		<Setting name="ColorID" type="int">1</Setting>
 		<Setting name="Nickname" type="unicode">Unnamed Traveler</Setting>
-		<Setting name="MinimapRotation" type="bool">False</Setting>
+		<Setting name="MinimapRotation" type="bool">True</Setting>
 		<Setting name="EdgeScrolling" type="bool">True</Setting>
 		<Setting name="UninterruptedBuilding" type="bool">False</Setting>
 		<Setting name="NetworkPort" type="unicode">0</Setting>


### PR DESCRIPTION
The minimap looks better when rotated with the map, so it's better to enable that setting by default.