### PR TITLE
numpad plus and minus keys also set game speed.

### DIFF
--- a/content/settings-template.xml
+++ b/content/settings-template.xml
@@ -83,8 +83,8 @@
 		<Setting name="DESTROY_TOOL" type="list"> X </Setting>
 		<Setting name="ROTATE_RIGHT" type="list"> PERIOD </Setting>
 		<Setting name="ROTATE_LEFT" type="list"> COMMA </Setting>
-		<Setting name="SPEED_UP" type="list"> PLUS ; EQUALS </Setting>
-		<Setting name="SPEED_DOWN" type="list"> MINUS </Setting>
+		<Setting name="SPEED_UP" type="list"> PLUS ; EQUALS ; KP_PLUS</Setting>
+		<Setting name="SPEED_DOWN" type="list"> MINUS ;  ; KP_MINUS</Setting>
 		<Setting name="ZOOM_IN" type="list"> PAGE_DOWN </Setting>
 		<Setting name="ZOOM_OUT" type="list"> PAGE_UP </Setting>
 		<Setting name="REMOVE_SELECTED" type="list"> DELETE </Setting>


### PR DESCRIPTION
This solves the original problem of issue #2450 by also binding numpad plus and mins keys too speed up and speed down.

These bindings can not be seen or changed in settings menu.
This might be confusing for some players, but it seemed a general improvement anyways.
For some reason the key detector in the settings menu detects numpad plus as `PLUS` instead of `KP_PLUS`, making it impossible to bind the numpad keys from the settings.
Also, there are already two other bindings for speedup and the settings menu can only show 2 bindings.

This only sets the default, so if you already had a settings.xml this won't do anything.
You should delete your settings file (or copy-paste the changed lines from the template) for this to take effect.