### PR TITLE
change how buildings are placed and drawn

### DIFF
--- a/horizons/util/loaders/sqliteanimationloader.py
+++ b/horizons/util/loaders/sqliteanimationloader.py
@@ -30,22 +30,13 @@ class SQLiteAnimationLoader:
 	def __init__(self):
 		pass
 
-	def loadResource(self, location):
+	def loadResource(self, anim_id):
 		"""
-		@param location: String with the location. See below for details:
-		Location format: <animation_id>:<command>:<params> (e.g.: "123:shift:left-16, bottom-8)
-		Available commands:
-		- shift:
-		Shift the image using the params left, right, center, middle for x shifting and
-		y-shifting with the params: top, bottom, center, middle.
-		A param looks like this: "param_x(+/-)value, param_y(+/-)value" (e.g.: left-16, bottom+8)
-		- cut:
-		#TODO: complete documentation
+		@param anim_id: String with the location
 		"""
-		commands = location.split(':')
-		anim_id = commands.pop(0)
+
+		anim_id = location
 		actionset, action, rotation = anim_id.split('+')
-		commands = list(zip(commands[0::2], commands[1::2]))
 
 		animationmanager = horizons.globals.fife.animationmanager
 
@@ -61,30 +52,7 @@ class SQLiteAnimationLoader:
 		for f in sorted(loader.get_sets()[actionset][action][int(rotation)].keys()):
 			frame_end = loader.get_sets()[actionset][action][int(rotation)][f]
 			img = horizons.globals.fife.imagemanager.load(f)
-			for command, arg in commands:
-				if command == 'shift':
-					x, y = arg.split(',')
-					if x.startswith('left'):
-						x = int(x[4:]) + int(img.getWidth() // 2)
-					elif x.startswith('right'):
-						x = int(x[5:]) - int(img.getWidth() // 2)
-					elif x.startswith(('center', 'middle')):
-						x = int(x[6:])
-					else:
-						x = int(x)
-
-					if y.startswith('top'):
-						y = int(y[3:]) + int(img.getHeight() // 2)
-					elif y.startswith('bottom'):
-						y = int(y[6:]) - int(img.getHeight() // 2)
-					elif y.startswith(('center', 'middle')):
-						y = int(y[6:])
-					else:
-						y = int(y)
-
-					img.setXShift(x)
-					img.setYShift(y)
-
+			img.setYShift(int(img.getWidth() / 4 - img.getHeight() / 2))
 			ani.addFrame(img, max(1, int((float(frame_end) - frame_start) * 1000)))
 			frame_start = float(frame_end)
 		# currently unused. would trigger onInstanceActionFrame of

--- a/horizons/util/loaders/sqliteanimationloader.py
+++ b/horizons/util/loaders/sqliteanimationloader.py
@@ -32,7 +32,7 @@ class SQLiteAnimationLoader:
 
 	def loadResource(self, anim_id):
 		"""
-		@param anim_id: String with the location
+		@param anim_id: String identifier for the image, eg "as_hunter0+idle+135"
 		"""
 
 		actionset, action, rotation = anim_id.split('+')

--- a/horizons/util/loaders/sqliteanimationloader.py
+++ b/horizons/util/loaders/sqliteanimationloader.py
@@ -35,7 +35,6 @@ class SQLiteAnimationLoader:
 		@param anim_id: String with the location
 		"""
 
-		anim_id = location
 		actionset, action, rotation = anim_id.split('+')
 
 		animationmanager = horizons.globals.fife.animationmanager

--- a/horizons/util/loaders/sqliteanimationloader.py
+++ b/horizons/util/loaders/sqliteanimationloader.py
@@ -76,4 +76,5 @@ class SQLiteAnimationLoader:
 			img = horizons.globals.fife.imagemanager.get(f)
 		else:
 			img = horizons.globals.fife.imagemanager.create(f)
+			img.forceLoadInternal() # make sure width and height can be read
 		return img

--- a/horizons/util/loaders/sqliteatlasloader.py
+++ b/horizons/util/loaders/sqliteatlasloader.py
@@ -57,7 +57,7 @@ class SQLiteAtlasLoader:
 		"""
 		@param anim_id: String identifier for the image, eg "as_hunter0+idle+135"
 		"""
-		print(anim_id)
+
 		if not self.inited:
 			self.init()
 		actionset, action, rotation = anim_id.split('+')

--- a/horizons/util/loaders/sqliteatlasloader.py
+++ b/horizons/util/loaders/sqliteatlasloader.py
@@ -53,24 +53,13 @@ class SQLiteAtlasLoader:
 			self.atlaslib.append(img)
 		self.inited = True
 
-	def loadResource(self, location):
+	def loadResource(self, id):
 		"""
-		@param location: String with the location. See below for details:
-		Location format: <animation_id>:<command>:<params> (e.g.: "123:shift:left-16, bottom-8)
-		Available commands:
-		- shift:
-		Shift the image using the params left, right, center, middle for x shifting and
-		y-shifting with the params: top, bottom, center, middle.
-		A param looks like this: "param_x(+/-)value, param_y(+/-)value" (e.g.: left-16, bottom+8)
-		- cut:
-		#TODO: complete documentation
+		@param id: String with the location.
 		"""
 		if not self.inited:
 			self.init()
-		commands = location.split(':')
-		id = commands.pop(0)
 		actionset, action, rotation = id.split('+')
-		commands = list(zip(commands[0::2], commands[1::2]))
 
 		animationmanager = horizons.globals.fife.animationmanager
 
@@ -97,30 +86,7 @@ class SQLiteAtlasLoader:
 				region = fife.Rect(xpos, ypos, width, height)
 				img.useSharedImage(self.atlaslib[entry[1]], region)
 
-			for command, arg in commands:
-				if command == 'shift':
-					x, y = arg.split(',')
-					if x.startswith('left'):
-						x = int(x[4:]) + (width // 2)
-					elif x.startswith('right'):
-						x = int(x[5:]) - (width // 2)
-					elif x.startswith(('center', 'middle')):
-						x = int(x[6:])
-					else:
-						x = int(x)
-
-					if y.startswith('top'):
-						y = int(y[3:]) + (height // 2)
-					elif y.startswith('bottom'):
-						y = int(y[6:]) - (height // 2)
-					elif y.startswith(('center', 'middle')):
-						y = int(y[6:])
-					else:
-						y = int(y)
-
-					img.setXShift(x)
-					img.setYShift(y)
-
+			img.setYShift(int(img.getWidth() / 4 - img.getHeight() / 2))
 			frame_end = entry[0]
 			ani.addFrame(img, max(1, int((frame_end - frame_start) * 1000)))
 			frame_start = frame_end

--- a/horizons/util/loaders/sqliteatlasloader.py
+++ b/horizons/util/loaders/sqliteatlasloader.py
@@ -55,8 +55,9 @@ class SQLiteAtlasLoader:
 
 	def loadResource(self, anim_id):
 		"""
-		@param anim_id: String with the location.
+		@param anim_id: String identifier for the image, eg "as_hunter0+idle+135"
 		"""
+		print(anim_id)
 		if not self.inited:
 			self.init()
 		actionset, action, rotation = anim_id.split('+')

--- a/horizons/util/loaders/sqliteatlasloader.py
+++ b/horizons/util/loaders/sqliteatlasloader.py
@@ -53,21 +53,21 @@ class SQLiteAtlasLoader:
 			self.atlaslib.append(img)
 		self.inited = True
 
-	def loadResource(self, id):
+	def loadResource(self, anim_id):
 		"""
-		@param id: String with the location.
+		@param anim_id: String with the location.
 		"""
 		if not self.inited:
 			self.init()
-		actionset, action, rotation = id.split('+')
+		actionset, action, rotation = anim_id.split('+')
 
 		animationmanager = horizons.globals.fife.animationmanager
 
 		# if we've loaded that animation before, we can finish early
-		if animationmanager.exists(id):
-			return animationmanager.getPtr(id)
+		if animationmanager.exists(anim_id):
+			return animationmanager.getPtr(anim_id)
 
-		ani = animationmanager.create(id)
+		ani = animationmanager.create(anim_id)
 
 		# Set the correct loader based on the actionset
 		loader = self._get_loader(actionset)

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -96,11 +96,7 @@ class BuildingClass(IngameType):
 		for rotation in all_action_sets[action_set][action_id]:
 			params['rot'] = rotation
 			assert rotation == 45 or rotation == 135 or rotation == 225 or rotation == 315, "Bad rotation for action_set {id}: {rot} for action: {action}".format(**params)
-			# (cls.size[1] + cls.size[0]) * VIEW.CELL_IMAGE_DIMENSIONS[1] / 4 == image.width / 4
-			# this is the distance between the bottom of the image and the point in the image
-			# representing the center of the object
-			params["botm"] = int((cls.size[1] + cls.size[0]) * VIEW.CELL_IMAGE_DIMENSIONS[1] / 4)
-			path = '{id}+{action}+{rot}:shift:center+0,bottom+{botm}'.format(**params)
+			path = '{id}+{action}+{rot}'.format(**params)
 			anim = horizons.globals.fife.animationloader.loadResource(path)
 			action.get2dGfxVisual().addAnimation(int(rotation), anim)
 			action.setDuration(anim.getDuration())

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -28,7 +28,6 @@ from horizons.i18n import gettext as T
 from horizons.util.loaders.actionsetloader import ActionSetLoader
 from horizons.world.ingametype import IngameType
 from horizons.world.production.producer import Producer
-from horizons.constants import VIEW
 
 
 class BuildingClass(IngameType):

--- a/horizons/world/building/__init__.py
+++ b/horizons/world/building/__init__.py
@@ -28,6 +28,7 @@ from horizons.i18n import gettext as T
 from horizons.util.loaders.actionsetloader import ActionSetLoader
 from horizons.world.ingametype import IngameType
 from horizons.world.production.producer import Producer
+from horizons.constants import VIEW
 
 
 class BuildingClass(IngameType):
@@ -94,76 +95,12 @@ class BuildingClass(IngameType):
 		fife.ActionVisual.create(action)
 		for rotation in all_action_sets[action_set][action_id]:
 			params['rot'] = rotation
-			# hacks to solve issue #1379
-			if rotation == 45:
-				# default values
-				params['botm'] = 16 * cls.size[0]
-				params['left'] = 32
-				# hack for smeltery
-				if cls.size[0] == 4 and cls.size[1] == 4:
-					params["botm"] = 75
-				elif cls.size[0] == 3:
-					params["botm"] = 66
-				# hack for charcoal_burning
-				elif cls.size[0] == 2 and cls.size[1] == 3:
-					params["botm"] = 55
-					params["left"] = 25
-				elif cls.size[0] == 2:
-					params["botm"] = 40
-				elif cls.size[0] == 1:
-					params["botm"] = 29
-			elif rotation == 135:
-				# default values
-				params['botm'] = 30
-				params['left'] = 32 * cls.size[1]
-				# hack for charcoal_burning
-				if cls.size[0] == 2 and cls.size[1] == 3:
-					params["botm"] = 35
-					params["left"] = 65
-			elif rotation == 225:
-				# default values
-				params['botm'] = 16 * cls.size[1]
-				params['left'] = 32 * (cls.size[0] + cls.size[1] - 1)
-				# hack for smeltery
-				if cls.size[0] == 4 and cls.size[1] == 4:
-					params["botm"] = 75
-				elif cls.size[0] == 3:
-					params["botm"] = 60
-				# hack for brickyard
-				elif cls.size[0] == 2 and cls.size[1] == 4:
-					params["botm"] = 73
-				# hack for charcoal_burning
-				elif cls.size[0] == 2 and cls.size[1] == 3:
-					params["botm"] = 42
-					params["left"] = 130
-				elif cls.size[0] == 2:
-					params["botm"] = 40
-				elif cls.size[0] == 1:
-					params["botm"] = 29
-			elif rotation == 315:
-				# default values
-				params['left'] = 32 * cls.size[0]
-				params['botm'] = 16 * (cls.size[0] + cls.size[1] - 1)
-				# hack for smeltery
-				if cls.size[0] == 4 and cls.size[1] == 4:
-					params["botm"] = 125
-					params["left"] = 135
-				elif cls.size[0] == 3:
-					params["botm"] = 96
-				# hack for brickyard
-				elif cls.size[0] == 2 and cls.size[1] == 4:
-					params["botm"] = 92
-				# hack for charcoal_burning
-				elif cls.size[0] == 2 and cls.size[1] == 3:
-					params["botm"] = 75
-					params["left"] = 100
-				elif cls.size[0] == 2:
-					params["botm"] = 56
-				elif cls.size[0] == 1:
-					params["botm"] = 30
-			else:
-				assert False, "Bad rotation for action_set {id}: {rot} for action: {action}".format(**params)
-			path = '{id}+{action}+{rot}:shift:left-{left},bottom+{botm}'.format(**params)
+			assert rotation == 45 or rotation == 135 or rotation == 225 or rotation == 315, "Bad rotation for action_set {id}: {rot} for action: {action}".format(**params)
+			# (cls.size[1] + cls.size[0]) * VIEW.CELL_IMAGE_DIMENSIONS[1] / 4 == image.width / 4
+			# this is the distance between the bottom of the image and the point in the image
+			# representing the center of the object
+			params["botm"] = int((cls.size[1] + cls.size[0]) * VIEW.CELL_IMAGE_DIMENSIONS[1] / 4)
+			path = '{id}+{action}+{rot}:shift:center+0,bottom+{botm}'.format(**params)
 			anim = horizons.globals.fife.animationloader.loadResource(path)
 			action.get2dGfxVisual().addAnimation(int(rotation), anim)
 			action.setDuration(anim.getDuration())

--- a/horizons/world/building/building.py
+++ b/horizons/world/building/building.py
@@ -235,7 +235,7 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 		if rotation == 135 or rotation == 315:
 			# if you look at a non-square builing from a 45 degree angle it looks
 			# different than from a 135 degree angle
-			# when you rotate it the with becomes the length and the length becomes the width
+			# when you rotate it the width becomes the length and the length becomes the width
 			width, length = length, width
 
 		# the drawing origin is the center of it's area, minus 0.5

--- a/horizons/world/building/building.py
+++ b/horizons/world/building/building.py
@@ -233,6 +233,9 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 
 		width, length = cls.size
 		if rotation == 135 or rotation == 315:
+			# if you look at a non-square builing from a 45 degree angle it looks
+			# different than from a 135 degree angle
+			# when you rotate it the with becomes the length and the length becomes the width
 			width, length = length, width
 
 		# the drawing origin is the center of it's area, minus 0.5
@@ -260,7 +263,7 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 				# set first action
 				action = list(action_set.keys())[0]
 
-		instance.actRepeat(action + "_" + str(action_set_id), rotation)
+		instance.actRepeat("{}_{:d}".format(action, action_set_id), rotation)
 		return (instance, action_set_id)
 
 	@classmethod

--- a/horizons/world/building/building.py
+++ b/horizons/world/building/building.py
@@ -230,62 +230,21 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 		#rotation = cls.check_build_rotation(session, rotation, x, y)
 		# TODO: replace this with new buildable api
 		# IDEA: save rotation in savegame
-		facing_loc = fife.Location(session.view.layers[cls.layer])
-		instance_coords = list((x, y, 0))
-		layer_coords = list((x, y, 0))
+
 		width, length = cls.size
+		if rotation == 135 or rotation == 315:
+			width, length = length, width
 
-		# NOTE:
-		# nobody actually knows how the code below works.
-		# it's for adapting the facing location and instance coords in
-		# different rotations, and works with all quadratic buildings (tested up to 4x4)
-		# for the first unquadratic building (2x4), a hack fix was put into it.
-		# the plan for fixing this code in general is to wait until there are more
-		# unquadratic buildings, and figure out a pattern of the placement error,
-		# then fix that generally.
+		# the drawing origin is the center of it's area, minus 0.5
+		# the 0.5 isn't really necessary, but other code is aligned with the 0.5 shift
+		# this is at least for the gridoverlay, and the location of a build preview relative to the mouse
+		# it this is changed, it should also be changed for ground tiles (world/ground.py) and units
+		instance_coords = [x + width / 2 - 0.5, y + length / 2 - 0.5, 0]
 
-		if rotation == 45:
-			layer_coords[0] = x + width + 3
-
-			if width == 2 and length == 4:
-				# HACK: fix for 4x2 buildings
-				instance_coords[0] -= 1
-				instance_coords[1] += 1
-
-		elif rotation == 135:
-			instance_coords[1] = y + length - 1
-			layer_coords[1] = y - length - 3
-
-			if width == 2 and length == 4:
-				# HACK: fix for 4x2 buildings
-				instance_coords[0] += 1
-				instance_coords[1] -= 1
-
-		elif rotation == 225:
-			instance_coords = list(( x + width - 1, y + length - 1, 0))
-			layer_coords[0] = x - width - 3
-
-			if width == 2 and length == 4:
-				# HACK: fix for 4x2 buildings
-				instance_coords[0] += 1
-				instance_coords[1] -= 1
-
-		elif rotation == 315:
-			instance_coords[0] = x + width - 1
-			layer_coords[1] = y + length + 3
-
-			if width == 2 and length == 4:
-				# HACK: fix for 4x2 buildings
-				instance_coords[0] += 1
-				instance_coords[1] -= 1
-
-		else:
-			return None
 		instance = session.view.layers[cls.layer].createInstance(
 			cls._fife_object,
-			fife.ModelCoordinate(*instance_coords),
+			fife.ExactModelCoordinate(*instance_coords),
 			world_id)
-		facing_loc.setLayerCoordinates(fife.ModelCoordinate(*layer_coords))
 
 		if action_set_id is None:
 			action_set_id = cls.get_random_action_set(level=level)
@@ -301,7 +260,7 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 				# set first action
 				action = list(action_set.keys())[0]
 
-		instance.actRepeat(action + "_" + str(action_set_id), facing_loc)
+		instance.actRepeat(action + "_" + str(action_set_id), rotation)
 		return (instance, action_set_id)
 
 	@classmethod

--- a/horizons/world/building/building.py
+++ b/horizons/world/building/building.py
@@ -262,8 +262,7 @@ class BasicBuilding(ComponentHolder, ConcreteObject):
 			else:
 				# set first action
 				action = list(action_set.keys())[0]
-
-		instance.actRepeat("{}_{:d}".format(action, action_set_id), rotation)
+		instance.actRepeat("{}_{}".format(action, action_set_id), rotation)
 		return (instance, action_set_id)
 
 	@classmethod

--- a/horizons/world/units/__init__.py
+++ b/horizons/world/units/__init__.py
@@ -91,8 +91,7 @@ class UnitClass(IngameType):
 		for rotation in all_action_sets[action_set][action_id]:
 			params['rot'] = rotation
 			# for more fine-tuned adjustments see horizons/world/building/__init__.py
-			path = '{id}+{action}+{rot}:shift:center+0,bottom+20'.format(**params)
-			# incorrect shift; to be done later
+			path = '{id}+{action}+{rot}'.format(**params)
 			anim = horizons.globals.fife.animationloader.loadResource(path)
 			action.get2dGfxVisual().addAnimation(int(rotation), anim)
 			action.setDuration(anim.getDuration())

--- a/horizons/world/units/__init__.py
+++ b/horizons/world/units/__init__.py
@@ -92,6 +92,7 @@ class UnitClass(IngameType):
 			params['rot'] = rotation
 			# for more fine-tuned adjustments see horizons/world/building/__init__.py
 			path = '{id}+{action}+{rot}:shift:center+0,bottom+20'.format(**params)
+			# incorrect shift; to be done later
 			anim = horizons.globals.fife.animationloader.loadResource(path)
 			action.get2dGfxVisual().addAnimation(int(rotation), anim)
 			action.setDuration(anim.getDuration())


### PR DESCRIPTION
Buildings are now drawn with as origin the center of their area (minus (0.5,0.5) to align with other parts of the code).
A y shift is used to position the image correctly (since the center of the image is almost always different than the center of the building).
This fixes #1379
The command passing for shifts if removed; the loaders are able to determine the proper shift themselves (based on image sizes)

Because the center is set as the origin, that is also the point for determining the z value of the building, and with that the ordering. This fixes #661

There are a few problems that remain:
- Buildings built on grass aren't aligned exactly with the grass. This is a problem from the grass sprites. (see #2807)
- For non-square buildings the ordering might be off sometimes. This is a result of using a single point as the z value. It can only be fixed by using multi-tile buildings.