### PR TITLE
minimap rotation always matches main view rotation (fixes #2783)

### DIFF
--- a/horizons/editor/gui.py
+++ b/horizons/editor/gui.py
@@ -73,8 +73,8 @@ class IngameGui(LivingObject):
 		self.mainhud.mapEvents({
 			'zoomIn': self.session.view.zoom_in,
 			'zoomOut': self.session.view.zoom_out,
-			'rotateRight': Callback.ChainedCallbacks(self.session.view.rotate_right, self.minimap.rotate_right),
-			'rotateLeft': Callback.ChainedCallbacks(self.session.view.rotate_left, self.minimap.rotate_left),
+			'rotateRight': Callback.ChainedCallbacks(self.session.view.rotate_right, self.minimap.update_rotation),
+			'rotateLeft': Callback.ChainedCallbacks(self.session.view.rotate_left, self.minimap.update_rotation),
 			'gameMenuButton': self.toggle_pause,
 		})
 

--- a/horizons/gui/ingamegui.py
+++ b/horizons/gui/ingamegui.py
@@ -129,8 +129,8 @@ class IngameGui(LivingObject):
 		self.mainhud.mapEvents({
 			'zoomIn' : self.session.view.zoom_in,
 			'zoomOut' : self.session.view.zoom_out,
-			'rotateRight' : Callback.ChainedCallbacks(self.session.view.rotate_right, self.minimap.rotate_right),
-			'rotateLeft' : Callback.ChainedCallbacks(self.session.view.rotate_left, self.minimap.rotate_left),
+			'rotateRight' : Callback.ChainedCallbacks(self.session.view.rotate_right, self.minimap.update_rotation),
+			'rotateLeft' : Callback.ChainedCallbacks(self.session.view.rotate_left, self.minimap.update_rotation),
 			'speedUp' : speed_up,
 			'speedDown' : speed_down,
 			'destroy_tool' : self.toggle_destroy_tool,
@@ -508,13 +508,13 @@ class IngameGui(LivingObject):
 				self.cursor.rotate_right()
 			else:
 				self.session.view.rotate_right()
-				self.minimap.rotate_right()
+				self.minimap.update_rotation()
 		elif action == _Actions.ROTATE_LEFT:
 			if hasattr(self.cursor, "rotate_left"):
 				self.cursor.rotate_left()
 			else:
 				self.session.view.rotate_left()
-				self.minimap.rotate_left()
+				self.minimap.update_rotation()
 		elif action == _Actions.CHAT:
 			self.windows.open(self.chat_dialog)
 		elif action == _Actions.TRANSLUCENCY:


### PR DESCRIPTION
The rotation of the main view used to be stored in the savegame, but the minimap rotation would reset everytime a session is started,
Because of this the minimap could have a different rotation than the main view.
This update fixes that by making the minimap read the view rotation whenever a session is started or when the screen is rotated.

Also added some parameter documentation for MinimapTransform