### PR TITLE
capped items per trade slot at 50; fix/workaround for #1095

### DIFF
--- a/content/gui/xml/ingame/tabwidget/warehouse/trade_single_slot.xml
+++ b/content/gui/xml/ingame/tabwidget/warehouse/trade_single_slot.xml
@@ -9,5 +9,7 @@
 
 	<!-- icon to show how much is in the inventory. size and position are set at runtime -->
 	<Icon name="fillbar" image="content/gui/images/tabwidget/green_line.png" size="0,0" />
-	<Slider name="slider" orientation="1" size="10,50" position="45,10" scale_start="1" is_focusable="0" />
+	
+	<!-- slider.height must always be at least constants.STORAGE.ITEMS_PER_SLOT + marker_length + 1 -->
+	<Slider name="slider" orientation="1" size="10,55" position="45,1" scale_start="1" is_focusable="0" marker_length="4"/>
 </Container>

--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -559,6 +559,13 @@ class STORAGE:
 	SHIP_TOTAL_SLOTS_NUMBER = 4
 
 
+	# The maximum number of items you can set in a trade route slot or warehouse trade slot
+	# This was actually only added to make sure the number wouldn't overflow the amount slider
+	# If more items can be traded than pixels in the slider it is impossible to accurately select an amount
+	# See https://github.com/unknown-horizons/unknown-horizons/issues/1095
+	ITEMS_PER_TRADE_SLOT = 50
+
+
 ## ENGINE
 class LAYERS:
 	WATER = 0

--- a/horizons/gui/tabs/buyselltab.py
+++ b/horizons/gui/tabs/buyselltab.py
@@ -26,7 +26,7 @@ from fife import fife
 
 from horizons.command.uioptions import ClearTradeSlot, SetTradeSlot
 from horizons.component.tradepostcomponent import TradePostComponent
-from horizons.constants import TRADER
+from horizons.constants import TRADER, STORAGE
 from horizons.extscheduler import ExtScheduler
 from horizons.gui.tabs.tabinterface import TabInterface
 from horizons.gui.util import create_resource_selection_dialog, get_res_icon_path, load_uh_widget
@@ -152,8 +152,8 @@ class BuySellTab(TabInterface):
 			slot.findChild(name='button').path = self.dummy_icon_path
 			slider = slot.findChild(name="slider")
 			slider.scale_start = 0.0
-			slider.scale_end = float(self.trade_post.get_inventory().limit)
-			# Set scale according to the settlement inventory size
+			slider.scale_end = float(min(self.trade_post.get_inventory().limit, STORAGE.ITEMS_PER_TRADE_SLOT))
+			# Set scale according to the settlement inventory size, with a cap
 			slot.findChild(name="buysell").capture(Callback(self.toggle_buysell, i))
 			fillbar = slot.findChild(name="fillbar")
 			# hide fillbar by setting position

--- a/horizons/gui/widgets/routeconfig.py
+++ b/horizons/gui/widgets/routeconfig.py
@@ -31,6 +31,7 @@ from horizons.command.unit import CreateRoute
 from horizons.component.ambientsoundcomponent import AmbientSoundComponent
 from horizons.component.namedcomponent import NamedComponent
 from horizons.component.storagecomponent import StorageComponent
+from horizons.constants import STORAGE
 from horizons.gui.util import create_resource_selection_dialog, get_res_icon_path, load_uh_widget
 from horizons.gui.widgets.imagebutton import OkButton
 from horizons.gui.widgets.minimap import Minimap
@@ -328,7 +329,9 @@ class RouteConfig(Window):
 
 			slider = slot.findChild(name="slider")
 			slider.scale_start = 0.0
-			slider.scale_end = float(self.instance.get_component(StorageComponent).inventory.limit)
+			slider.scale_end = float(
+				min(self.instance.get_component(StorageComponent).inventory.limit,
+					STORAGE.ITEMS_PER_TRADE_SLOT))
 
 			slot.findChild(name="buysell").capture(Callback(self.toggle_load_unload, slot, entry))
 


### PR DESCRIPTION
Unfortunately it isn't possible to set multiple slots to the same resource (this would require large changes to TradePostComponent and TradeRoute), so 50 is the cap for automatically trading that resource