### PR TITLE
Fire mousemoved events even when they were consumed by widgets

### DIFF
--- a/horizons/engine/engine.py
+++ b/horizons/engine/engine.py
@@ -160,7 +160,8 @@ class Fife:
 			# see issue #2778 and #1413
 			# to fix this, mousemove events are fired even when over a widget
 			def isFiltered(self, event):
-				return bool(event.getType() == fife.MouseEvent.MOVED)
+				return event.getType() == fife.MouseEvent.MOVED or \
+					event.getType() == fife.MouseEvent.RELEASED
 		# storing it as a member is important to prevent segfaults
 		# this is probably because otherwise it will be garbage collected
 		self._mouseFilter = MouseMoveFilter()

--- a/horizons/engine/engine.py
+++ b/horizons/engine/engine.py
@@ -153,6 +153,18 @@ class Fife:
 
 		# Init stuff.
 		self.eventmanager = self.engine.getEventManager()
+
+		class MouseMoveFilter(fife.IMouseFilter):
+			# by default no mousemove events are fired when the mouse moves over a widget
+			# this is problematic since it is not possible to tell when the mouse enters a widget
+			# see issue #2778 and #1413
+			# to fix this, mousemove events are fired even when over a widget
+			def isFiltered(self, event):
+				return bool(event.getType() == fife.MouseEvent.MOVED)
+		# storing it as a member is important to prevent segfaults
+		# this is probably because otherwise it will be garbage collected
+		self._mouseFilter = MouseMoveFilter()
+		self.eventmanager.setMouseFilter(self._mouseFilter)
 		self.sound = Sound(self)
 		self.imagemanager = self.engine.getImageManager()
 		self.animationmanager = self.engine.getAnimationManager()

--- a/horizons/gui/mousetools/attackingtool.py
+++ b/horizons/gui/mousetools/attackingtool.py
@@ -64,7 +64,7 @@ class AttackingTool(SelectionTool):
 	def mouseMoved(self, evt):
 		super().mouseMoved(evt)
 		target = self._get_attackable_instance(evt)
-		if target:
+		if target and not evt.isConsumedByWidgets():
 			horizons.globals.fife.set_cursor_image("attacking")
 		else:
 			horizons.globals.fife.set_cursor_image("default")

--- a/horizons/gui/mousetools/buildingtool.py
+++ b/horizons/gui/mousetools/buildingtool.py
@@ -478,6 +478,8 @@ class BuildingTool(NavigationTool):
 	def mouseMoved(self, evt):
 		self.log.debug("BuildingTool mouseMoved")
 		super().mouseMoved(evt)
+		if evt.isConsumedByWidgets():
+			return
 		point = self.get_world_location(evt)
 		if self.start_point != point:
 			self.start_point = point
@@ -501,6 +503,8 @@ class BuildingTool(NavigationTool):
 	def mouseDragged(self, evt):
 		self.log.debug("BuildingTool mouseDragged")
 		super().mouseDragged(evt)
+		if evt.isConsumedByWidgets():
+			return
 		point = self.get_world_location(evt)
 		if self.start_point is not None:
 			self._check_update_preview(point)

--- a/horizons/gui/mousetools/navigationtool.py
+++ b/horizons/gui/mousetools/navigationtool.py
@@ -133,6 +133,8 @@ class NavigationTool(CursorTool):
 
 	# return new mouse position after moving
 	def mouseMoved(self, evt):
+		#print(dir(evt))
+		print(evt.getType(), evt.getName(), evt.getSource(), evt.isConsumed(), evt.isConsumedByWidgets())
 		if not self.session.world.inited:
 			return
 

--- a/horizons/gui/mousetools/pipettetool.py
+++ b/horizons/gui/mousetools/pipettetool.py
@@ -50,7 +50,8 @@ class PipetteTool(NavigationTool):
 		self.session.ingame_gui.set_cursor()
 
 	def mouseMoved(self, evt):
-		self.update_coloring(evt)
+		if not evt.isConsumedByWidgets():
+			self.update_coloring(evt)
 
 	def mousePressed(self, evt):
 		if evt.getButton() == fife.MouseEvent.LEFT:

--- a/horizons/gui/mousetools/tearingtool.py
+++ b/horizons/gui/mousetools/tearingtool.py
@@ -70,7 +70,9 @@ class TearingTool(NavigationTool):
 	def mouseMoved(self, evt):
 		super().mouseMoved(evt)
 		coords = self.get_world_location(evt).to_tuple()
-		self._mark(coords)
+		self._restore_transparent_instances()
+		if not evt.isConsumedByWidgets():
+			self._mark(coords)
 		evt.consume()
 
 	def on_escape(self):
@@ -133,7 +135,6 @@ class TearingTool(NavigationTool):
 
 	def _mark(self, *edges):
 		"""Highights building instances and keeps self.selected up to date."""
-		self._restore_transparent_instances()
 		self.log.debug("TearingTool: mark")
 		if len(edges) == 1:
 			edges = (edges[0], edges[0])

--- a/horizons/gui/mousetools/tilelayingtool.py
+++ b/horizons/gui/mousetools/tilelayingtool.py
@@ -112,7 +112,8 @@ class TileLayingTool(NavigationTool):
 
 	def update_coloring(self, evt):
 		self._remove_coloring()
-		self._add_coloring(self.get_world_location(evt).to_tuple())
+		if not evt.isConsumedByWidgets():
+			self._add_coloring(self.get_world_location(evt).to_tuple())
 
 	def _add_coloring(self, pos):
 		brush = Circle(Point(*pos), self.session.world_editor.brush_size - 1)


### PR DESCRIPTION
Use mousefilter to let the mousemoved and mousereleased events pass through.
This allows the mousetools to properly know the position of the mouse, even when widgets are in front of it.

This PR requires a FIFE to call `MouseEvent.consumedByWidgets()`. See https://github.com/fifengine/fifengine/pull/1059
Do not merge this until FIFE is changed.

This should solve problems #1413, #2778 and #2787.
If this would be done the workaround for #1413 (extending the gui menus) should be undone