### PR TITLE
NavigationTool listens to mouseevents behind widgets

### DIFF
--- a/horizons/gui/mousetools/attackingtool.py
+++ b/horizons/gui/mousetools/attackingtool.py
@@ -40,7 +40,7 @@ class AttackingTool(SelectionTool):
 		super().__init__(session)
 
 	def mousePressed(self, evt):
-		if evt.getButton() == fife.MouseEvent.RIGHT:
+		if evt.getButton() == fife.MouseEvent.RIGHT and not evt.isConsumedByWidgets():
 			target_mapcoord = self.session.view.cam.toMapCoordinates(
 				fife.ScreenPoint(evt.getX(), evt.getY()), False)
 

--- a/horizons/gui/mousetools/pipettetool.py
+++ b/horizons/gui/mousetools/pipettetool.py
@@ -53,7 +53,7 @@ class PipetteTool(NavigationTool):
 		self.update_coloring(evt)
 
 	def mousePressed(self, evt):
-		if evt.getButton() == fife.MouseEvent.LEFT:
+		if evt.getButton() == fife.MouseEvent.LEFT and not evt.isConsumedByWidgets():
 			obj = self._get_object(evt)
 			if obj and self._is_buildable(obj.id):
 				self.session.ingame_gui.set_cursor('building', Entities.buildings[obj.id])

--- a/horizons/gui/mousetools/tearingtool.py
+++ b/horizons/gui/mousetools/tearingtool.py
@@ -79,7 +79,7 @@ class TearingTool(NavigationTool):
 	def mouseReleased(self, evt):
 		"""Tear selected instances and set selection tool as cursor"""
 		self.log.debug("TearingTool: mouseReleased")
-		if evt.getButton() == fife.MouseEvent.LEFT:
+		if evt.getButton() == fife.MouseEvent.LEFT and not evt.isConsumedByWidgets():
 			coords = self.get_world_location(evt).to_tuple()
 			if self.coords is None:
 				self.coords = coords
@@ -123,7 +123,7 @@ class TearingTool(NavigationTool):
 	def mousePressed(self, evt):
 		if evt.getButton() == fife.MouseEvent.RIGHT:
 			self.on_escape()
-		elif evt.getButton() == fife.MouseEvent.LEFT:
+		elif evt.getButton() == fife.MouseEvent.LEFT and not evt.isConsumedByWidgets():
 			self.coords = self.get_world_location(evt).to_tuple()
 			self._mark(self.coords)
 		else:

--- a/horizons/gui/mousetools/tilelayingtool.py
+++ b/horizons/gui/mousetools/tilelayingtool.py
@@ -80,7 +80,10 @@ class TileLayingTool(NavigationTool):
 		self.session.ingame_gui.set_cursor()
 
 	def mouseMoved(self, evt):
-		self.update_coloring(evt)
+		if evt.isConsumedByWidgets():
+			self._remove_coloring()
+		else:
+			self.update_coloring(evt)
 
 	def _place_tile(self, coords):
 		brush = Circle(Point(*coords), self.session.world_editor.brush_size - 1)
@@ -92,7 +95,7 @@ class TileLayingTool(NavigationTool):
 		return self._round_map_coords(mapcoords.x + 0.5, mapcoords.y + 0.5)
 
 	def mousePressed(self, evt):
-		if evt.getButton() == fife.MouseEvent.LEFT:
+		if evt.getButton() == fife.MouseEvent.LEFT and not evt.isConsumeByWidgets():
 			coords = self.get_world_location(evt).to_tuple()
 			self._place_tile(coords)
 			evt.consume()


### PR DESCRIPTION
All its subclasses as well.
This is done by setting it as a global listener.
This requires the latest git version of FIFE.
isConsumedByWidgets is used to check whether to fire or not.

This should solve problems #1413, #2778 and #2787.

This probably requires some playtesting.
It is likely that I missed some case where the mouseevent should not have fired through a widget.