### PR TITLE
fix #2819 by checking if view is None

### DIFF
--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -622,6 +622,8 @@ class Minimap:
 
 	def update_rotation(self):
 		# ensure the minimap rotation matches the main view rotation
+		if not self.view:
+			return
 		self.transform.set_rotation(self.view.cam.getRotation())
 		self.draw()
 


### PR DESCRIPTION
It might be possible now that the minimap is rotated incorrectly when starting the game.
Whenever the view rotates this is corrected again.