### PR TITLE
redraw whole minimap when a settlement is placed

### DIFF
--- a/horizons/gui/widgets/minimap.py
+++ b/horizons/gui/widgets/minimap.py
@@ -305,9 +305,10 @@ class Minimap:
 		@param tup: (x, y)"""
 		if self.world is None or not self.world.inited:
 			return # don't draw while loading
-		minimap_point = self.transform.world_to_minimap(tup)
+		if tup is not None:
+			tup = self.transform.world_to_minimap(tup)
 
-		self._recalculate(minimap_point)
+		self._recalculate(tup)
 
 	def use_overlay_icon(self, icon):
 		"""Configures icon so that clicks get mapped here.

--- a/horizons/world/island.py
+++ b/horizons/world/island.py
@@ -275,9 +275,9 @@ class Island(BuildingOwner, WorldObject):
 		settlement_tiles_changed = []
 		for coords in settlement_coords_changed:
 			settlement_tiles_changed.append(self.ground_map[coords])
-			Minimap.update(coords)
 			if coords in flat_land_set:
 				self.available_flat_land -= 1
+		Minimap.update(None)
 		self.available_land_cache.remove_area(settlement_coords_changed)
 
 		self._register_change()
@@ -316,9 +316,9 @@ class Island(BuildingOwner, WorldObject):
 				clean_coords.add(coords)
 			settlement_tiles_changed.append(self.ground_map[coords])
 			del settlement.ground_map[coords]
-			Minimap.update(coords)
 			if coords in flat_land_set:
 				self.available_flat_land += 1
+		Minimap.update(None)
 		self.available_land_cache.add_area(clean_coords)
 
 		self._register_change()


### PR DESCRIPTION
When a new settlement was made on a small map, not all pixels of the settlement would be coloured in the minimap.
This was because the minimap received a list of main map coordinates, but some main map coordinates correspond to multiple minimap coordinates. This means that some pixels in between are sometimes left empty.

Normal redrawing of the minimap draw all pixels. This update makes sure the minimap is redrawn when a settlement is placed.

The map editor probably has a similar problem that is not solved in this PR (because tile changes there are too common to redraw the minimap each time)