### PR TITLE
fix #2828: implement horizontal mousewheel methods in cursortool

### DIFF
--- a/horizons/gui/mousetools/cursortool.py
+++ b/horizons/gui/mousetools/cursortool.py
@@ -74,6 +74,12 @@ class CursorTool(fife.IMouseListener):
 	def mouseWheelMovedDown(self, evt):
 		pass
 
+	def mouseWheelMovedLeft(self, evt):
+		pass
+
+	def mouseWheelMovedRight(self, evt):
+		pass
+
 	def mouseMoved(self, evt):
 		pass
 


### PR DESCRIPTION
The IMouseListener subclasses can crash if not all listener methods are implemented.
This gives the rare mouseWheelMovedRight and mouseWheelMovedLeft an empty implementation.