### PR TITLE
key settings use fife's listener instead of fifechan's (fix #2156)

### DIFF
--- a/content/settings-template.xml
+++ b/content/settings-template.xml
@@ -82,8 +82,8 @@
 		<Setting name="DESTROY_TOOL" type="list"> X </Setting>
 		<Setting name="ROTATE_RIGHT" type="list"> PERIOD </Setting>
 		<Setting name="ROTATE_LEFT" type="list"> COMMA </Setting>
-		<Setting name="SPEED_UP" type="list"> PLUS ; EQUALS ; KP_PLUS</Setting>
-		<Setting name="SPEED_DOWN" type="list"> MINUS ;  ; KP_MINUS</Setting>
+		<Setting name="SPEED_UP" type="list"> EQUALS ; KP_PLUS</Setting>
+		<Setting name="SPEED_DOWN" type="list"> MINUS ; KP_MINUS</Setting>
 		<Setting name="ZOOM_IN" type="list"> PAGE_DOWN </Setting>
 		<Setting name="ZOOM_OUT" type="list"> PAGE_UP </Setting>
 		<Setting name="REMOVE_SELECTED" type="list"> DELETE </Setting>

--- a/horizons/gui/modules/hotkeys_settings.py
+++ b/horizons/gui/modules/hotkeys_settings.py
@@ -55,11 +55,10 @@ class HotkeyConfiguration:
 		# Stores whether the last button pressed was for a primary or secondary binding (1 or 2)
 		self.last_column = 1
 
-		# There are some keys which are not detected by the event widget/keyPressed
-		# In that case, the key presses are detected by the listener, which calls _detect_keypress
+		# This used to go though the widget's key events, but fifechan has different keynames
+		# Using a fife keylistener ensures that the in-game keys always match
 		self.listener = HotkeysListener(self._detect_keypress)
 
-		self.widget.mapEvents({self.widget.name + '/keyPressed' : self._detect_keypress})
 		self.widget.findChild(name=OkButton.DEFAULT_NAME).capture(self.save_settings)
 		self.widget.mapEvents({OkButton.DEFAULT_NAME : self.save_settings})
 		self.widget.findChild(name="reset_to_default").capture(self.reset_to_default)
@@ -80,7 +79,7 @@ class HotkeyConfiguration:
 
 	def _create_button(self, action, index):
 		"""Important! The button name is set to index so that when a button is pressed, we know its index"""
-		button = Button()
+		button = Button(is_focusable=False)
 		button.name = str(index)
 		button.max_size = button.min_size = (100, 18)
 		return button


### PR DESCRIPTION
The listener for setting hotkeys used to use fifechan's keynames.
These don't completely match fife's keynames (for example for numpad keys)
This change makes the settings use the same listener that is used in game.

Also, this undoes #2792.
That PR was a workaround, but only gives trouble now the underlying problem is fixed.