### PR TITLE
fix test_settler_level_save_load

### DIFF
--- a/horizons/world/building/settler.py
+++ b/horizons/world/building/settler.py
@@ -220,13 +220,9 @@ class Settler(BuildableRect, BuildingResourceHandler, BasicBuilding):
 
 	def _tick(self):
 		"""Here we collect the functions, that are called regularly (every "month")."""
-		print("> happiness", self.happiness)
 		self.pay_tax()
-		print("  tax happiness", self.happiness)
 		self.inhabitant_check()
-		print("  inhabitant happiness", self.happiness)
 		self.level_check()
-		print("< happiness", self.happiness)
 
 	def pay_tax(self):
 		"""Pays the tax for this settler"""
@@ -313,7 +309,6 @@ class Settler(BuildableRect, BuildingResourceHandler, BasicBuilding):
 		# just level up later that tick, it could disturb other code higher in the call stack
 
 		def _do_level_up():
-			print("Levelup", self.level, self.level+1)
 			self.level += 1
 			self.log.debug("%s: Levelling up to %s", self, self.level)
 			self._update_level_data()

--- a/horizons/world/building/settler.py
+++ b/horizons/world/building/settler.py
@@ -220,9 +220,13 @@ class Settler(BuildableRect, BuildingResourceHandler, BasicBuilding):
 
 	def _tick(self):
 		"""Here we collect the functions, that are called regularly (every "month")."""
+		print("> happiness", self.happiness)
 		self.pay_tax()
+		print("  tax happiness", self.happiness)
 		self.inhabitant_check()
+		print("  inhabitant happiness", self.happiness)
 		self.level_check()
+		print("< happiness", self.happiness)
 
 	def pay_tax(self):
 		"""Pays the tax for this settler"""
@@ -309,6 +313,7 @@ class Settler(BuildableRect, BuildingResourceHandler, BasicBuilding):
 		# just level up later that tick, it could disturb other code higher in the call stack
 
 		def _do_level_up():
+			print("Levelup", self.level, self.level+1)
 			self.level += 1
 			self.log.debug("%s: Levelling up to %s", self, self.level)
 			self._update_level_data()

--- a/tests/game/test_load_save.py
+++ b/tests/game/test_load_save.py
@@ -230,22 +230,43 @@ def test_settler_level_save_load(s, p):
 		settler.level += test_level
 		settler_worldid = settler.worldid
 
+		settlement.tax_settings[settler.level] = -0.5
+
+		print("")
+
+		print("level", settler.level, test_level)
+		print("taxing ", settlement.tax_settings[settler.level])
+
 		# make it happy
 		inv = settler.get_component(StorageComponent).inventory
 		to_give = inv.get_free_space_for(RES.HAPPINESS)
 		inv.alter(RES.HAPPINESS, to_give)
 		level = settler.level
+		print("begin happiness1", inv[RES.HAPPINESS])
 
 		# wait for it to realize it's supposed to upgrade
 		s.run(seconds=GAME.INGAME_TICK_INTERVAL)
 
+		assert settler.level == level
+
+		print("presaveload happiness1", inv[RES.HAPPINESS])
 		session = saveload(session)
 		settler = WorldObject.get_object_by_id(settler_worldid)
 		inv = settler.get_component(StorageComponent).inventory
 
+
+		print("postsaveload happiness1", inv[RES.HAPPINESS])
+
+		assert settler.level == level
+
 		# continue
 		s.run(seconds=GAME.INGAME_TICK_INTERVAL)
 
+
+		print("postrun happiness1", inv[RES.HAPPINESS])
+
+		assert inv[RES.BOARDS] == 0
+		assert inv[RES.BRICKS] == 0
 		assert settler.level == level
 		# give upgrade res
 		inv.alter(RES.BOARDS, 100)

--- a/tests/game/test_load_save.py
+++ b/tests/game/test_load_save.py
@@ -228,42 +228,31 @@ def test_settler_level_save_load(s, p):
 
 		settler = Build(BUILDINGS.RESIDENTIAL, 22, 22, island, settlement=settlement)(p)
 		settler.level += test_level
+		settler._update_level_data(True, True)
 		settler_worldid = settler.worldid
 
 		settlement.tax_settings[settler.level] = -0.5
-
-		print("")
-
-		print("level", settler.level, test_level)
-		print("taxing ", settlement.tax_settings[settler.level])
 
 		# make it happy
 		inv = settler.get_component(StorageComponent).inventory
 		to_give = inv.get_free_space_for(RES.HAPPINESS)
 		inv.alter(RES.HAPPINESS, to_give)
+		settler.inhabitants = settler.inhabitants_max
 		level = settler.level
-		print("begin happiness1", inv[RES.HAPPINESS])
 
 		# wait for it to realize it's supposed to upgrade
 		s.run(seconds=GAME.INGAME_TICK_INTERVAL)
 
 		assert settler.level == level
 
-		print("presaveload happiness1", inv[RES.HAPPINESS])
 		session = saveload(session)
 		settler = WorldObject.get_object_by_id(settler_worldid)
 		inv = settler.get_component(StorageComponent).inventory
-
-
-		print("postsaveload happiness1", inv[RES.HAPPINESS])
 
 		assert settler.level == level
 
 		# continue
 		s.run(seconds=GAME.INGAME_TICK_INTERVAL)
-
-
-		print("postrun happiness1", inv[RES.HAPPINESS])
 
 		assert inv[RES.BOARDS] == 0
 		assert inv[RES.BRICKS] == 0


### PR DESCRIPTION
The test_settler_level_save_load test was supposed to test if a house upgrades correctly after saving and reloading the session.
It failed to take into account that there might not be enough inhabitants or that the inhabitants aren't happy enough.
This sets the taxes so that the inhabitants stay happy, and it makes sure that there are enought inhabitants.

The test still doesn't really make sense since there are 2 sessions: the one passed as argument and a newly created session. The building is placed in the argument session, and the waiting is there as well, while the save/load is done on the new session. I tried to fix this but that crashed it.
At least the test now makes a bit more sense.