### PR TITLE
Follow XDG basedir specifications; fix #2749

### DIFF
--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from horizons.ext.enum import Enum
-from horizons.util.platform import get_user_game_directory
+from horizons.util.platform import get_old_user_game_directory, get_user_game_directories
 
 
 """This file keeps track of the constants that are used in Unknown Horizons.
@@ -592,33 +592,25 @@ class GFX:
 
 
 ## PATHS
-# workaround, so it can be used to create paths within PATHS
 
-
-if 'UH_USER_DIR' in os.environ:
-	# Prefer the value from the environment. Used to override user dir when
-	# running GUI tests.
-	_user_dir = os.environ['UH_USER_DIR']
-else:
-	_user_dir = str(get_user_game_directory())
-	if not os.path.exists(_user_dir):
-		os.makedirs(_user_dir)
+_config_dir, _data_dir, _cache_dir = get_user_game_directories()
 
 
 class PATHS:
-	# paths in user dir
-	USER_DIR = _user_dir
-	LOG_DIR = os.path.join(USER_DIR, "log")
-	USER_MAPS_DIR = os.path.join(USER_DIR, "maps")
-	USER_CONFIG_FILE = os.path.join(USER_DIR, "settings.xml")
-	SCREENSHOT_DIR = os.path.join(USER_DIR, "screenshots")
-	SAVEGAME_DIR = os.path.join(USER_DIR, "save")
-	CACHE_DIR = USER_DIR
-	DEFAULT_WINDOW_ICON_PATH = os.path.join("content", "gui", "images", "logos", "uh_32.png")
-	MAC_WINDOW_ICON_PATH = os.path.join("content", "gui", "icons", "Icon.icns")
+	# paths in user directories
+	USER_CONFIG_FILE = os.path.join(_config_dir, "settings.xml")
+	USER_DATA_DIR = _data_dir
+	LOG_DIR = os.path.join(USER_DATA_DIR, "log")
+	USER_MAPS_DIR = os.path.join(USER_DATA_DIR, "maps")
+	SCREENSHOT_DIR = os.path.join(USER_DATA_DIR, "screenshots")
+	SAVEGAME_DIR = os.path.join(USER_DATA_DIR, "save")
+	CACHE_DIR = _cache_dir
 	ATLAS_METADATA_PATH = os.path.join(CACHE_DIR, "atlas-metadata.cache")
 
 	# paths relative to uh dir
+	DEFAULT_WINDOW_ICON_PATH = os.path.join("content", "gui", "images", "logos", "uh_32.png")
+	MAC_WINDOW_ICON_PATH = os.path.join("content", "gui", "icons", "Icon.icns")
+
 	ACTION_SETS_DIRECTORY = os.path.join("content", "gfx")
 	TILE_SETS_DIRECTORY = os.path.join("content", "gfx", "base")
 	SAVEGAME_TEMPLATE = os.path.join("content", "savegame_template.sql")
@@ -646,6 +638,15 @@ class PATHS:
 	#voice paths
 	VOICE_DIR = os.path.join("content", "audio", "voice")
 	UH_LOGO_FILE = os.path.join("content", "gfx", "uh.png")
+
+
+_old_user_dir = get_old_user_game_directory()
+
+
+class OLDPATHS:
+	USER_DATA_DIR = _old_user_dir
+	USER_CONFIG_FILE = os.path.join(_old_user_dir, "settings.xml")
+	CACHE_DIR = _old_user_dir
 
 
 class SETTINGS:

--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -611,9 +611,11 @@ class PATHS:
 	USER_MAPS_DIR = os.path.join(USER_DIR, "maps")
 	USER_CONFIG_FILE = os.path.join(USER_DIR, "settings.xml")
 	SCREENSHOT_DIR = os.path.join(USER_DIR, "screenshots")
+	SAVEGAME_DIR = os.path.join(PATHS.USER_DIR, "save")
+	CACHE_DIR = USER_DIR
 	DEFAULT_WINDOW_ICON_PATH = os.path.join("content", "gui", "images", "logos", "uh_32.png")
 	MAC_WINDOW_ICON_PATH = os.path.join("content", "gui", "icons", "Icon.icns")
-	ATLAS_METADATA_PATH = os.path.join(USER_DIR, "atlas-metadata.cache")
+	ATLAS_METADATA_PATH = os.path.join(CACHE_DIR, "atlas-metadata.cache")
 
 	# paths relative to uh dir
 	ACTION_SETS_DIRECTORY = os.path.join("content", "gfx")

--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -576,19 +576,6 @@ class LAYERS:
 
 	NUM = 4 # number of layers
 
-## PATHS
-# workaround, so it can be used to create paths within PATHS
-
-
-if 'UH_USER_DIR' in os.environ:
-	# Prefer the value from the environment. Used to override user dir when
-	# running GUI tests.
-	_user_dir = os.environ['UH_USER_DIR']
-else:
-	_user_dir = str(get_user_game_directory())
-	if not os.path.exists(_user_dir):
-		os.makedirs(_user_dir)
-
 
 class GFX:
 	BUILDING_OUTLINE_THRESHOLD = 96
@@ -604,6 +591,20 @@ class GFX:
 	USE_ATLASES = False
 
 
+## PATHS
+# workaround, so it can be used to create paths within PATHS
+
+
+if 'UH_USER_DIR' in os.environ:
+	# Prefer the value from the environment. Used to override user dir when
+	# running GUI tests.
+	_user_dir = os.environ['UH_USER_DIR']
+else:
+	_user_dir = str(get_user_game_directory())
+	if not os.path.exists(_user_dir):
+		os.makedirs(_user_dir)
+
+
 class PATHS:
 	# paths in user dir
 	USER_DIR = _user_dir
@@ -611,7 +612,7 @@ class PATHS:
 	USER_MAPS_DIR = os.path.join(USER_DIR, "maps")
 	USER_CONFIG_FILE = os.path.join(USER_DIR, "settings.xml")
 	SCREENSHOT_DIR = os.path.join(USER_DIR, "screenshots")
-	SAVEGAME_DIR = os.path.join(PATHS.USER_DIR, "save")
+	SAVEGAME_DIR = os.path.join(USER_DIR, "save")
 	CACHE_DIR = USER_DIR
 	DEFAULT_WINDOW_ICON_PATH = os.path.join("content", "gui", "images", "logos", "uh_32.png")
 	MAC_WINDOW_ICON_PATH = os.path.join("content", "gui", "icons", "Icon.icns")

--- a/horizons/savegamemanager.py
+++ b/horizons/savegamemanager.py
@@ -53,7 +53,7 @@ class SavegameManager:
 	"""
 	log = logging.getLogger("savegamemanager")
 
-	savegame_dir = os.path.join(PATHS.USER_DIR, "save")
+	savegame_dir = PATHS.SAVEGAME_DIR
 	autosave_dir = os.path.join(savegame_dir, "autosave")
 	multiplayersave_dir = os.path.join(savegame_dir, "multiplayer_save")
 	quicksave_dir = os.path.join(savegame_dir, "quicksave")

--- a/horizons/util/__init__.py
+++ b/horizons/util/__init__.py
@@ -25,7 +25,10 @@ import os
 def create_user_dirs():
 	"""Creates the userdir and subdirs. Includes from horizons."""
 	from horizons.constants import PATHS
+	from horizons.util.migratepaths import migrate_paths
 
-	for directory in (PATHS.USER_DIR, PATHS.LOG_DIR, PATHS.USER_MAPS_DIR, PATHS.SCREENSHOT_DIR):
+	migrate_paths()
+
+	for directory in (PATHS.LOG_DIR, PATHS.USER_MAPS_DIR, PATHS.SCREENSHOT_DIR):
 		if not os.path.isdir(directory):
 			os.makedirs(directory)

--- a/horizons/util/migratepaths.py
+++ b/horizons/util/migratepaths.py
@@ -1,3 +1,23 @@
+# ###################################################
+# Copyright (C) 2018 The Unknown Horizons Team
+# team@unknown-horizons.org
+# This file is part of Unknown Horizons.
+#
+# Unknown Horizons is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the
+# Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# ###################################################
 
 import glob
 import os

--- a/horizons/util/migratepaths.py
+++ b/horizons/util/migratepaths.py
@@ -1,0 +1,79 @@
+
+import glob
+import os
+
+from horizons.constants import OLDPATHS, PATHS
+
+
+def migrate_paths():
+
+	migrated = False
+	if check_cache_migration():
+		migrate_cache()
+		# cache migration doesn't really need a link or mention I think
+
+	if check_config_migration():
+		migrate_config()
+		link_config()
+		migrated = True
+
+	if check_data_migration():
+		migrate_data()
+		link_data()
+		migrated = True
+
+	if migrated:
+		leave_note()
+
+
+def check_cache_migration():
+	return os.path.isdir(OLDPATHS.CACHE_DIR) and not os.path.isdir(PATHS.CACHE_DIR)
+
+
+def migrate_cache():
+	cache_files = glob.glob(os.path.join(OLDPATHS.CACHE_DIR, "*.cache"))
+	for oldname in cache_files:
+		newname = os.path.join(PATHS.CACHE_DIR, os.path.basename(oldname))
+		os.renames(oldname, newname)
+
+
+def check_config_migration():
+	return os.path.isfile(OLDPATHS.USER_CONFIG_FILE) and not os.path.isfile(PATHS.USER_CONFIG_FILE)
+
+
+def migrate_config():
+	os.renames(OLDPATHS.USER_CONFIG_FILE, PATHS.USER_CONFIG_FILE)
+
+
+def link_config():
+	os.symlink(PATHS.USER_CONFIG_FILE, OLDPATHS.USER_CONFIG_FILE)
+
+
+def check_data_migration():
+	return os.path.isdir(OLDPATHS.USER_DATA_DIR) and not os.path.isdir(PATHS.USER_DATA_DIR)
+
+
+def migrate_data():
+	os.renames(OLDPATHS.USER_DATA_DIR, PATHS.USER_DATA_DIR)
+
+
+def link_data():
+	os.symlink(PATHS.USER_DATA_DIR, OLDPATHS.USER_DATA_DIR)
+
+
+def leave_note():
+	notefile = os.path.join(PATHS.USER_DATA_DIR, "migration_readme.txt")
+	notetext = """
+In the latest version of unknown-horizons the user data directories have been moved.
+This has been done automatically, and symlinks have been created to minimize inconvenience.
+
+It is safe to remove these symlinks and this readme file.
+
+If you ever downgrade the UH version you might need more care.
+
+For more information, see the wiki:
+https://github.com/unknown-horizons/unknown-horizons/wiki/2018-user-data-migration
+"""
+	print(notetext)
+	with open(notefile, 'w') as f:
+		f.write(notetext)

--- a/horizons/util/migratepaths.py
+++ b/horizons/util/migratepaths.py
@@ -67,13 +67,19 @@ def leave_note():
 In the latest version of unknown-horizons the user data directories have been moved.
 This has been done automatically, and symlinks have been created to minimize inconvenience.
 
+The data is now in the following directories:
+
+settings.xml: {configfile}
+screenshots, saves, maps and logs: {datadir}
+cache: {cachedir}
+
 It is safe to remove these symlinks and this readme file.
 
 If you ever downgrade the UH version you might need more care.
 
 For more information, see the wiki:
 https://github.com/unknown-horizons/unknown-horizons/wiki/2018-user-data-migration
-"""
+""".format(configfile=PATHS.USER_CONFIG_FILE, datadir=PATHS.USER_DATA_DIR, cachedir=PATHS.CACHE_DIR)
 	print(notetext)
 	with open(notefile, 'w') as f:
 		f.write(notetext)

--- a/horizons/util/platform.py
+++ b/horizons/util/platform.py
@@ -21,7 +21,6 @@
 
 import os
 import platform
-from pathlib import PurePath
 
 CSIDL_PERSONAL = 5 # 'My documents' folder for win32 API
 
@@ -31,21 +30,86 @@ def get_home_directory():
 	Returns the home directory of the user running UH.
 	"""
 	if platform.system() != "Windows":
-		return PurePath(os.path.expanduser('~'))
+		return os.path.expanduser('~')
 	else:
 		import ctypes.wintypes
 		buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
 		# get the My Documents folder into buf.value
 		ctypes.windll.shell32.SHGetFolderPathW(0, CSIDL_PERSONAL, 0, 0, buf)
-		return PurePath(buf.value)
+		return buf.value
 
 
-def get_user_game_directory():
+# define here as string to reduce chance of typos
+UH = "unknown-horizons"
+
+
+def get_old_user_game_directory():
 	"""
-	Returns the directory where we store game-related data, such as savegames.
+	Returns the old directory where for game-related data.
+	This is used when migrating from the old structure to the new
 	"""
+	user_dir = os.environ.get("UH_USER_DIR")
+	if user_dir: # not None or empty string
+		return user_dir
+
 	home_directory = get_home_directory()
 	if platform.system() != "Windows":
-		return home_directory.joinpath('.unknown-horizons')
+		return os.path.join(home_directory, "." + UH)
 	else:
-		return home_directory.joinpath('My Games', 'unknown-horizons')
+		return os.path.join(home_directory, 'My Games', UH)
+
+
+def _try_directories(paths, default=None):
+	# takes a list of lists of strings as first argument
+	# returns the joined path for the first list where all strings exist and are nonempty
+	# or the second argument there is no such list
+	# (lists coul also be tuples of course)
+	for parts in paths:
+		if all(parts):
+			return os.path.join(parts)
+	return default
+
+
+def get_user_game_directories():
+	"""
+	Returns a triplet of directories for game-related data.
+	The first value is the directory for configuration files (settings.xml)
+	The second is the directory for game data (saves, maps, screenshots, logs)
+	The third is the directory for cache (atlas-metadata.cache, yamldata.cache)
+	"""
+	home_directory = get_home_directory()
+
+	# these are the default directories
+	if platform.system() == "Windows":
+		user_dir = os.path.join(home_directory, 'My Games', UH)
+		config_dir = user_dir
+		data_dir = user_dir
+		cache_dir = os.path.join(user_dir, "cache")
+	else:
+		config_dir = os.path.join(home_directory, ".config", UH)
+		data_dir = os.path.join(home_directory, ".local", "share", UH)
+		cache_dir = os.path.join(home_directory, ".cache", UH)
+
+	# for each of the directories, try the paths with environment variables in this order
+	# if one of the environment variables exists, use that path
+	# otherwise, keep using the default dir
+
+	config_dir = _try_directories([
+		(os.environ.get("UH_USER_CONFIG_DIR"),),
+		(os.environ.get("UH_USER_DIR"),),
+		(os.environ.get("XDG_CONFIG_HOME"), UH)],
+		config_dir)
+
+	data_dir = _try_directories([
+		(os.environ.get("UH_USER_DATA_DIR"),),
+		(os.environ.get("UH_USER_DIR"),),
+		(os.environ.get("XDG_DATA_HOME"), UH)],
+		data_dir)
+
+	cache_dir = _try_directories([
+		(os.environ.get("UH_USER_CACHE_DIR"),),
+		(os.environ.get("UH_USER_DIR"), "cache"),
+		(os.environ.get("XDG_CACHE_HOME"), UH)],
+		cache_dir)
+
+	return config_dir, data_dir, cache_dir

--- a/horizons/util/platform.py
+++ b/horizons/util/platform.py
@@ -62,8 +62,8 @@ def get_old_user_game_directory():
 def _try_directories(paths, default=None):
 	# takes a list of lists of strings as first argument
 	# returns the joined path for the first list where all strings exist and are nonempty
-	# or the second argument there is no such list
-	# (lists coul also be tuples of course)
+	# or the second argument if there is no such list
+	# (lists could also be tuples of course)
 	for parts in paths:
 		if all(parts):
 			return os.path.join(parts)

--- a/horizons/util/yamlcache.py
+++ b/horizons/util/yamlcache.py
@@ -89,7 +89,7 @@ class YamlCache:
 	"""
 
 	cache = None # type: Optional[YamlCacheStorage]
-	cache_filename = os.path.join(PATHS.USER_DIR, 'yamldata.cache')
+	cache_filename = os.path.join(PATHS.CACHE_DIR, 'yamldata.cache')
 
 	sync_scheduled = False
 

--- a/tests/unittests/misc/test_paths.py
+++ b/tests/unittests/misc/test_paths.py
@@ -44,7 +44,7 @@ class TestPaths(TestCase):
 		inner = str(os.path.join(outer, self.__class__.odd_characters))
 		inner2 = str(os.path.join(outer, self.__class__.odd_characters + "2"))
 
-		PATHS.USER_DIR = inner
+		PATHS.USER_DATA_DIR = inner
 
 		create_user_dirs()
 


### PR DESCRIPTION
Unknown Horizons now puts user files in `$XDG_CONFIG_HOME/unknown-horizons`, `$XDG_DATA_HOME/unknown-horizons` and `$XDG_CACHE_HOME/unknown-horizons`.

For linux, the defaults are `~/.config/unknown-horizons`, `~/.local/share/unknown-horizons` and `~/.cache/unknown-horizons`.
For windows, the only difference is that the cache is placed in it's own directory (though it will also follow the XDG environment variables if they exist)

You can also override the paths using uh environment variables.
`$UH_USER_DIR` sets the directory for all user files. Data and config are both in this directory, and cache is in it's own subdirectory.
`$UH_USER_CONFIG_DIR`, `$UH_USER_DATA_DIR` and `$UH_USER_CACHE_DIR` can be used to set these directories indivually. These more specific options override `$UH_USER_DIR`.

If the new directories do not exist but the old ones do, the files at the old directory will be automatically moved to the new directory.
For config and data a symlink will be created from the old location to the new one, so users will be able to find their files back. This is also useful when switching back and forth between UH versions. A note describing the migration is left in the data directory. This note is also printed to stdout when the migration is happening. The note links to the wiki for more information: https://github.com/unknown-horizons/unknown-horizons/wiki/2018-user-data-migration

Users aren't informed about cache migration, because they shouldn't need to look at it manually anyways and when switching versions cache is very likely to be incompatible anyways


What do you think of this? I chose to make symlinks and leave a note instead of showing a popup because the migration only matters when users are looking at the directories anyways.

Also, could you also double-check for typos in filenames and environment variables? These are things that aren't easily caught. Maybe this part needs some tests?