### PR TITLE
fix E201 whitespace after '('

### DIFF
--- a/development/combat_ai/diplomacy_graphs.py
+++ b/development/combat_ai/diplomacy_graphs.py
@@ -112,5 +112,5 @@ def diplomacy_graph():
 		pylab.show()
 
 
-if __name__ == "__main__" :
+if __name__ == "__main__":
 	diplomacy_graph()

--- a/development/networkclient.py
+++ b/development/networkclient.py
@@ -280,7 +280,7 @@ if host is None or port is None or port <= 0:
 	usage()
 	sys.exit(1)
 
-logging.config.fileConfig( os.path.join('content', 'logging.conf'))
+logging.config.fileConfig(os.path.join('content', 'logging.conf'))
 logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 logging.getLogger("network").setLevel(logging.DEBUG)
 

--- a/development/print_db_data.py
+++ b/development/print_db_data.py
@@ -65,8 +65,8 @@ ExtScheduler.create_instance(Dummy()) # sometimes needed by entities in subseque
 Entities.load_buildings(db, load_now=True)
 Entities.load_units(load_now=True)
 
-building_name_mapping = dict( (b.id, b.name) for b in Entities.buildings.itervalues() )
-unit_name_mapping = dict( (u.id, u.name) for u in Entities.units.itervalues() )
+building_name_mapping = dict((b.id, b.name) for b in Entities.buildings.itervalues())
+unit_name_mapping = dict((u.id, u.name) for u in Entities.units.itervalues())
 
 
 def get_obj_name(obj):
@@ -186,7 +186,7 @@ def print_unit():
 def print_storage():
 	for b in Entities.buildings.itervalues():
 		try:
-			stor = b.get_component_template( StorageComponent )
+			stor = b.get_component_template(StorageComponent)
 		except KeyError:
 			continue
 		if not stor:
@@ -302,14 +302,14 @@ def print_names():
 
 
 def print_settler_needs():
-	klass = Entities.buildings[ BUILDINGS.RESIDENTIAL ]
-	comp = [ i for i in klass.component_templates if i.keys()[0] == u'ProducerComponent' ][0]
+	klass = Entities.buildings[BUILDINGS.RESIDENTIAL]
+	comp = [i for i in klass.component_templates if i.keys()[0] == u'ProducerComponent'][0]
 	lines = comp.values()[0][u'productionlines']
 	per_level = defaultdict(list)
 	for line_data in lines.itervalues():
 		level = line_data.get("level", [-1])
 		for l in level:
-			per_level[l].extend( [ res for (res, num) in line_data[u'consumes'] ] )
+			per_level[l].extend([res for (res, num) in line_data[u'consumes']])
 	data = dict((k, sorted(db.get_res_name(i) for i in v)) for k, v in per_level.iteritems())
 	print("Needed resources per tier")
 	pprint.pprint(data)
@@ -326,34 +326,34 @@ def print_settler_needs():
 
 
 functions = {
-		'actions' : print_scenario_actions,
-		'buildings' : print_building,
-		'building_costs' : print_building_costs,
-		'colors' : print_colors,
-		'collectors' : print_collectors,
+		'actions': print_scenario_actions,
+		'buildings': print_building,
+		'building_costs': print_building_costs,
+		'colors': print_colors,
+		'collectors': print_collectors,
 		'collector_restrictions': print_collector_restrictions,
-		'conditions' : print_scenario_conditions,
-		'tiers' : print_tier_data,
-		'lines' : print_production_lines,
-		'names' : print_names,
-		'resources' : print_res,
-		'settler_needs' : print_settler_needs,
-		'storage' : print_storage,
-		'units' : print_unit,
-		'verbose_lines' : print_production_lines,
+		'conditions': print_scenario_conditions,
+		'tiers': print_tier_data,
+		'lines': print_production_lines,
+		'names': print_names,
+		'resources': print_res,
+		'settler_needs': print_settler_needs,
+		'storage': print_storage,
+		'units': print_unit,
+		'verbose_lines': print_production_lines,
 		}
 abbrevs = {
-		'b' : 'buildings',
+		'b': 'buildings',
 		'bc': 'building_costs',
-		'building' : 'buildings',
-		'c' : 'collectors',
-		'cl' : 'colors',
+		'building': 'buildings',
+		'c': 'collectors',
+		'cl': 'colors',
 		'cr': 'collector_restrictions',
-		'i' : 'tiers',
-		'tier' : 'tiers',
-		'n' : 'names',
-		'pl' : 'lines',
-		'res' : 'resources',
+		'i': 'tiers',
+		'tier': 'tiers',
+		'n': 'names',
+		'pl': 'lines',
+		'res': 'resources',
 		'settler_lines': 'tiers',
 		'sl': 'tiers',
 		'sn': 'settler_needs',

--- a/development/stringpreviewwidget.py
+++ b/development/stringpreviewwidget.py
@@ -43,7 +43,7 @@ class StringPreviewWidget(Window):
 
 	def _init_gui(self, session):
 		self._gui = load_uh_widget("stringpreviewwidget.xml")
-		self._gui.mapEvents({ 'load' : self.load })
+		self._gui.mapEvents({'load': self.load})
 		self.scenarios = SavegameManager.get_scenarios()
 		self.listbox = self._gui.findChild(name="scenario_list")
 		self.listbox.items = self.scenarios[1]
@@ -55,7 +55,7 @@ class StringPreviewWidget(Window):
 		self.windows = WindowManager()
 		self.logbook = LogBook(session, self.windows)
 		self.logbook._gui.mapEvents({
-			OkButton.DEFAULT_NAME : self.logbook.hide,
+			OkButton.DEFAULT_NAME: self.logbook.hide,
 		})
 		self.update_infos()
 
@@ -93,6 +93,6 @@ class StringPreviewWidget(Window):
 		try:
 			self.logbook.set_cur_entry(cur_entry)
 		except ValueError:
-			pass # no entries
+			pass  # no entries
 		self.logbook._redraw_captainslog()
 		self.logbook.show()

--- a/development/translate_scenario.py
+++ b/development/translate_scenario.py
@@ -111,7 +111,7 @@ def compile_scenario_po(output_mo):
 			'-o', output_mo,
 		], stderr=subprocess.STDOUT)
 	except subprocess.CalledProcessError:
-		#TODO handle
+		# TODO handle
 		print('Error while compiling translation `{}`, probably malformed `.po`. '
 		      'Exiting.'.format(input_po))
 		sys.exit(1)

--- a/development/update_translations.py
+++ b/development/update_translations.py
@@ -138,7 +138,7 @@ def main():
 	sort_order = lambda e: LANGUAGENAMES.get_by_value(e[0], english=True)
 	for language, authors in sorted(language_authors.items(), key=sort_order):
 		print('\n####', language)
-		#TODO
+		# TODO
 		# The sorted() below will not correctly sort names containing non-ascii.
 		# You'll need to rely on manual copy/paste and ordering anyways, so just
 		# keep your eyes open a bit more than usual.

--- a/tests/game/test_blackdeath.py
+++ b/tests/game/test_blackdeath.py
@@ -38,10 +38,10 @@ def test_blackdeath_destroy(s):
 	# need this so that disaster can break out
 	s.world.player.settler_level = 4
 
-	assert settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]
+	assert settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]
 	inhabitants_before = settlement.inhabitants
 
-	residential_buildings = len(settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ])
+	residential_buildings = len(settlement.buildings_by_id[BUILDINGS.RESIDENTIAL])
 	assert residential_buildings > BlackDeathDisaster.MIN_INHABITANTS_FOR_BREAKOUT
 
 	while not dis_man._active_disaster:

--- a/tests/game/test_combat.py
+++ b/tests/game/test_combat.py
@@ -91,30 +91,30 @@ def test_equip(s, p):
 
 	(p0, s0), (p1, s1) = setup_combat(s, UNITS.FRIGATE)
 
-	assert s0.get_component(StorageComponent).inventory[ WEAPONS.CANNON ] == 0
-	assert s0.get_weapon_storage()[ WEAPONS.CANNON ] == WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM
+	assert s0.get_component(StorageComponent).inventory[WEAPONS.CANNON] == 0
+	assert s0.get_weapon_storage()[WEAPONS.CANNON] == WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM
 
 	# we don't have swords
 	not_equip = EquipWeaponFromInventory(s0, WEAPONS.SWORD, 1).execute(s)
 	assert not_equip == 1
-	assert s0.get_component(StorageComponent).inventory[ WEAPONS.SWORD ] == 0
-	assert s0.get_weapon_storage()[ WEAPONS.SWORD ] == 0
+	assert s0.get_component(StorageComponent).inventory[WEAPONS.SWORD] == 0
+	assert s0.get_weapon_storage()[WEAPONS.SWORD] == 0
 
 	# test equip
-	s0.get_component(StorageComponent).inventory.alter( WEAPONS.CANNON, 2 )
+	s0.get_component(StorageComponent).inventory.alter(WEAPONS.CANNON, 2)
 
 	# this has to work
 	not_equip = EquipWeaponFromInventory(s0, WEAPONS.CANNON, 1).execute(s)
 	assert not_equip == 0
 
-	assert s0.get_component(StorageComponent).inventory[ WEAPONS.CANNON ] == 1
+	assert s0.get_component(StorageComponent).inventory[WEAPONS.CANNON] == 1
 	assert s0.get_weapon_storage()[WEAPONS.CANNON] == WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM + 1
 
 	# too many
 	not_equip = EquipWeaponFromInventory(s0, WEAPONS.CANNON, 2).execute(s)
 
 	assert not_equip == 1
-	assert s0.get_component(StorageComponent).inventory[ WEAPONS.CANNON ] == 0
+	assert s0.get_component(StorageComponent).inventory[WEAPONS.CANNON] == 0
 	assert s0.get_weapon_storage()[WEAPONS.CANNON] == WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM + 2
 
 	# no swords
@@ -123,13 +123,13 @@ def test_equip(s, p):
 
 	not_equip = UnequipWeaponToInventory(s0, WEAPONS.CANNON, 2).execute(s)
 	assert not_equip == 0
-	assert s0.get_component(StorageComponent).inventory[ WEAPONS.CANNON ] == 2
+	assert s0.get_component(StorageComponent).inventory[WEAPONS.CANNON] == 2
 	assert s0.get_weapon_storage()[WEAPONS.CANNON] == WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM
 
 	not_equip = UnequipWeaponToInventory(s0, WEAPONS.CANNON, WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM).execute(s)
 	assert not_equip == 0
 
-	assert s0.get_component(StorageComponent).inventory[ WEAPONS.CANNON ] == 2 + WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM
+	assert s0.get_component(StorageComponent).inventory[WEAPONS.CANNON] == 2 + WEAPONS.DEFAULT_FIGHTING_SHIP_WEAPONS_NUM
 	assert s0.get_weapon_storage()[WEAPONS.CANNON] == 0
 
 

--- a/tests/game/test_fire.py
+++ b/tests/game/test_fire.py
@@ -40,8 +40,8 @@ def test_fire_destroy(s):
 	# need this so that fires can break out
 	s.world.player.settler_level = 1
 
-	assert settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]
-	old_num = len(settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ])
+	assert settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]
+	old_num = len(settlement.buildings_by_id[BUILDINGS.RESIDENTIAL])
 
 	while not dis_man._active_disaster:
 		dis_man.run() # try to seed until we have a fire
@@ -51,7 +51,7 @@ def test_fire_destroy(s):
 		s.run()
 
 	# it's not defined how bad a fire is, but some buildings should be destroyed in any case
-	assert len(settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]) < old_num
+	assert len(settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]) < old_num
 
 
 @game_test(use_fixture='fire')
@@ -71,7 +71,7 @@ def test_fire_station(s):
 	inv.alter(RES.BRICKS, 10)
 
 	# second lj is the pos we need
-	lj = settlement.buildings_by_id[ BUILDINGS.LUMBERJACK ][1]
+	lj = settlement.buildings_by_id[BUILDINGS.LUMBERJACK][1]
 	pos = lj.position.origin
 	owner = lj.owner
 	island = lj.island
@@ -79,8 +79,8 @@ def test_fire_station(s):
 	Tear(lj)(owner)
 	assert Build(BUILDINGS.FIRE_STATION, pos.x, pos.y, island, settlement=settlement)(owner)
 
-	assert settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]
-	old_num = len(settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ])
+	assert settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]
+	old_num = len(settlement.buildings_by_id[BUILDINGS.RESIDENTIAL])
 
 	for i in range(5): # 5 fires
 		while not dis_man._active_disaster:
@@ -91,7 +91,7 @@ def test_fire_station(s):
 			s.run()
 
 	# in this simple case, the fire station should be 100% effective
-	assert len(settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]) == old_num
+	assert len(settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]) == old_num
 
 
 @game_test(use_fixture='fire')
@@ -105,12 +105,14 @@ def test_upgrade_disallowed_with_fire(s):
 	# need this so that fires can break out
 	s.world.player.settler_level = 1
 
-	assert settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]
+	assert settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]
 
 	# Fullfil all needs to level up
-	for settler in settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]:
-		happiness = s.db("SELECT value FROM balance_values WHERE name = 'happiness_level_up_requirement'")[0][0]
-		settler.get_component(StorageComponent).inventory.alter(RES.HAPPINESS, happiness + 1)
+	for settler in settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]:
+		happiness = s.db("SELECT value FROM balance_values WHERE name = "
+						 "'happiness_level_up_requirement'")[0][0]
+		settler.get_component(StorageComponent).inventory.alter(
+			RES.HAPPINESS, happiness + 1)
 		settler.inhabitants = settler.inhabitants_min
 
 	# Now seed a fire

--- a/tests/game/test_settlement_range.py
+++ b/tests/game/test_settlement_range.py
@@ -32,23 +32,23 @@ def test_settlement_decrease(s):
 	Check if destroying a lookout destroys surrounding buildings but not trees.
 	"""
 	settlement = s.world.player.settlements[0]
-	lo = settlement.buildings_by_id[ BUILDINGS.LOOKOUT ][0]
+	lo = settlement.buildings_by_id[BUILDINGS.LOOKOUT][0]
 	pos = lo.position.origin
 	owner = lo.owner
 	island = lo.island
 
-	starting_tents = settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]
+	starting_tents = settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]
 	old_tents = len(starting_tents)
 
-	old_trees_owned = len(settlement.buildings_by_id[ BUILDINGS.TREE ])
+	old_trees_owned = len(settlement.buildings_by_id[BUILDINGS.TREE])
 	old_trees = island.num_trees
 
 	Tear(lo)(owner)
 
-	cur_tents = settlement.buildings_by_id[ BUILDINGS.RESIDENTIAL ]
+	cur_tents = settlement.buildings_by_id[BUILDINGS.RESIDENTIAL]
 	new_tents = len(cur_tents)
 
-	new_trees_owned = len(settlement.buildings_by_id[ BUILDINGS.TREE ])
+	new_trees_owned = len(settlement.buildings_by_id[BUILDINGS.TREE])
 	new_trees = island.num_trees
 
 	assert new_trees == old_trees

--- a/tests/game/test_status_icons.py
+++ b/tests/game/test_status_icons.py
@@ -112,7 +112,7 @@ def test_inventory_full(session, player):
 
 	inv = lj.get_component(StorageComponent).inventory
 	res = RES.BOARDS
-	inv.alter(res, inv.get_free_space_for( res ) )
+	inv.alter(res, inv.get_free_space_for(res))
 
 	session.run(seconds=1)
 


### PR DESCRIPTION
After this PR are still existing cases:
pycodestyle horizons tests *.py development --select E20 --stat
163     E201 whitespace after '('
395     E202 whitespace before ')'
767     E203 whitespace before ':'
1325
