### PR TITLE
make configure-traderoute button inactive if there are no destinations

### DIFF
--- a/horizons/gui/tabs/shiptabs.py
+++ b/horizons/gui/tabs/shiptabs.py
@@ -120,12 +120,11 @@ class ShipOverviewTab(OverviewTab):
 		if len(possible_warehouses) > 1:
 			events['configure_route'] = Callback(self._configure_route)
 			self.widget.findChild(name='configure_route').set_active()
-			self.widget.findChild(name='configure_route').helptext = T("Configure traderoute")
-			return
-
-		events['configure_route'] = None
-		self.widget.findChild(name='configure_route').set_inactive()
-		self.widget.findChild(name='configure_route').helptext = T("No available destinations for a trade route")
+			self.widget.findChild(name='configure_route').helptext = T("Configure trade route")
+		else:
+			events['configure_route'] = None
+			self.widget.findChild(name='configure_route').set_inactive()
+			self.widget.findChild(name='configure_route').helptext = T("No available destinations for a trade route")
 
 	def refresh(self):
 		events = {


### PR DESCRIPTION
Fix #2721 

Next step is to make the button look inactive. The xml template has a random image instead of a real inactive image so it may not be very clear.
Should I try to improve on that in the same Pull Request ?