### PR TITLE
sync graphics location for moving objects

### DIFF
--- a/horizons/world/units/movingobject.py
+++ b/horizons/world/units/movingobject.py
@@ -209,6 +209,18 @@ class MovingObject(ComponentHolder, ConcreteObject):
 		else:
 			self.__is_moving = True
 
+
+		# HACK: 2 different pathfinding systems are being used here and they
+		# might not always match.
+		# If the graphical location is too far away from the actual location,
+		# then forcefully synchronize the locations.
+		# This fixes the symptoms from issue #2859
+		# https://github.com/unknown-horizons/unknown-horizons/issues/2859
+		pos = fife.ExactModelCoordinate(self.position.x, self.position.y, 0)
+		fpos = self.fife_instance.getLocationRef().getExactLayerCoordinates()
+		if (pos - fpos).length() > 1.5:
+			self.fife_instance.getLocationRef().setExactLayerCoordinates(pos)
+
 		#setup movement
 		move_time = self.get_unit_velocity()
 		UnitClass.ensure_action_loaded(self._action_set_id, self._move_action) # lazy load move action


### PR DESCRIPTION
Units have 2 different pathfinders.
One is the UH one in python, which deals with the long path, but only works in integer coordinates.
The other one is Fife's route system, which does the part between two paths on UH's pathfinder so the movement looks smooth.

For some unknown reason, Fife's route system is not always able to go where it is supposed to go and the ship will get stuck. It then tries to correct with absurd movements. See #2859.

This patch will make sure that the location of the fife instance is never too far from the actual location by checking the fife location whenever the actual location updates.
If the two locations are too far away from each other, the fife location will be set to the actual location.

This might result in a little jump now and then, but those are the cases where the ship would have otherwise been stuck.
If this error is rare enough it won't be noticable.
Also, the error was more common on the higher game speeds where a little jump won't be noticable anyways