### PR TITLE
Fix test collection under python3.7

### DIFF
--- a/tests/dummy.py
+++ b/tests/dummy.py
@@ -44,7 +44,7 @@ class Dummy:
 			if attr in ('__base__', '__bases__', '__basicsize__',
 				'__dictoffset__', '__flags__', '__itemsize__',
 				'__members__', '__methods__', '__mro__', '__name__',
-				'__subclasses__', '__weakrefoffset__',
+				'__subclasses__', '__weakrefoffset__', '__mro_entries__',
 				'_getAttributeNames', 'mro'):
 				raise
 			else:


### PR DESCRIPTION
All I did was:

1. create a python3.7 virtualenv
2. install a few dependencies and `pytest` in the virtualenv
3. `pytest tests --collect-only` (and fix the error)