### PR TITLE
fixed test_paths and replaced deprecated code

### DIFF
--- a/horizons/util/__init__.py
+++ b/horizons/util/__init__.py
@@ -22,12 +22,13 @@
 import os
 
 
-def create_user_dirs():
+def create_user_dirs(migrate=True):
 	"""Creates the userdir and subdirs. Includes from horizons."""
 	from horizons.constants import PATHS
 	from horizons.util.migratepaths import migrate_paths
 
-	migrate_paths()
+	if migrate:
+		migrate_paths()
 
 	for directory in (PATHS.LOG_DIR, PATHS.USER_MAPS_DIR, PATHS.SCREENSHOT_DIR):
 		if not os.path.isdir(directory):

--- a/horizons/util/pathfinding/pathfinder.py
+++ b/horizons/util/pathfinding/pathfinder.py
@@ -46,7 +46,7 @@ def a_star_find_path(source, destination, nodes, clockwise=True):
 	@param nodes: object that provides __contains__ (dict, list) with items (x, y)
 	@param clockwise: bool; whether to try finding the path clockwise or counterclockwise
 	"""
-	assert isinstance(nodes, collections.Container)
+	assert isinstance(nodes, collections.abc.Container)
 
 	if source not in nodes or destination not in nodes:
 		return None

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -143,7 +143,7 @@ def pytest_runtest_makereport(item, call):
 	When a gui test fails, we replace the internal traceback with the one from the subprocess
 	stderr.
 	"""
-	report = (yield).result
+	report = (yield).get_result()
 	if report.when != 'call' or report.outcome != 'failed':
 		return report
 

--- a/tests/unittests/misc/test_paths.py
+++ b/tests/unittests/misc/test_paths.py
@@ -35,7 +35,7 @@ class TestPaths(TestCase):
 
 	def test_normal(self):
 
-		create_user_dirs()
+		create_user_dirs(migrate=False)
 
 	def test_special_character(self):
 		"""Make paths have special characters and check some basic operations"""
@@ -45,8 +45,12 @@ class TestPaths(TestCase):
 		inner2 = str(os.path.join(outer, self.__class__.odd_characters + "2"))
 
 		PATHS.USER_DATA_DIR = inner
+		PATHS.LOG_DIR = os.path.join(inner, "log")
+		PATHS.USER_MAPS_DIR = os.path.join(inner, "maps")
+		PATHS.SCREENSHOT_DIR = os.path.join(inner, "screenshots")
+		PATHS.SAVEGAME_DIR = os.path.join(inner, "save")
 
-		create_user_dirs()
+		create_user_dirs(migrate=False)
 
 		scenario_file = os.listdir(SavegameManager.scenarios_dir)[0]
 		shutil.copy(os.path.join(SavegameManager.scenarios_dir, scenario_file),
@@ -63,6 +67,7 @@ class TestPaths(TestCase):
 
 		SavegameManager.create_autosave_filename()
 
-		os.rmdir(inner)
+		for dirpath, _dirnames, _filenames in os.walk(inner, topdown=False):
+			os.rmdir(dirpath)
 		os.rmdir(inner2)
 		os.rmdir(outer)


### PR DESCRIPTION
Fix the path test that was broken in #2844

Replace deprecated access to pytest._Result.result and to collections.Container (pytest was warning about this).