### PR TITLE
Use wildcard in travis fife rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ script:
   - "cp -a /usr/lib/python3/dist-packages/enet* $VIRTUAL_ENV/lib/python3.6/site-packages/"
   - "prename 's/\\.cpython-36m-x86_64-linux-gnu/.cpython-36m/' $VIRTUAL_ENV/lib/python3.6/site-packages/enet*.so"
   #- "prename 's/\\.cpython-36m-x86_64-linux-gnu/.cpython-36m/' $VIRTUAL_ENV/lib/python3.6/site-packages/fife/*.so"
-  - mv $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fife.cpython-36m-x86_64-linux-gnu.so $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fife.so
-  - mv $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fifechan.cpython-36m-x86_64-linux-gnu.so $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fifechan.so
+  - mv $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fife.cpython-3*m-x86_64-linux-gnu.so $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fife.so
+  - mv $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fifechan.cpython-3*m-x86_64-linux-gnu.so $VIRTUAL_ENV/lib/python3.6/site-packages/fife/_fifechan.so
   - python3 -c 'from fife import fife; print(fife.getVersion())'
   - isort -c -rc horizons tests *.py
   - pycodestyle horizons tests *.py development


### PR DESCRIPTION
Use a wildcard in fife filename to rename so it works with different python versions.

This should make the fife package visible to python again when run in travis.