### PR TITLE
generate atlases during setup; should fix #2716

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,13 @@ import glob
 import json
 import os
 import platform
+import sys
 from distutils.command.build import build
 from distutils.core import setup
 from distutils.spawn import find_executable
 from shutil import copytree, rmtree
 
+import horizons
 from horizons.constants import VERSION
 from horizons.ext import polib
 
@@ -143,6 +145,11 @@ class _build_i18n(distutils.cmd.Command):
 
 		return mo_files
 
+	def generate_atlases(self, size):
+		horizons_path = os.path.dirname(horizons.__file__)
+		args = [sys.executable, os.path.join(horizons_path, 'engine', 'generate_atlases.py'), str(size)]
+		process = subprocess.Popen(args)
+
 	def run(self):
 		"""
 		Update the language files, generate mo files and add them
@@ -219,6 +226,10 @@ class _build_i18n(distutils.cmd.Command):
 			if os.path.exists(os.path.join("content", "lang")):
 				rmtree(os.path.join("content", "lang"))
 			copytree(os.path.join("build", "mo"), os.path.join("content", "lang"))
+
+		generate_atlases(2048)
+
+
 
 
 build.sub_commands.append(('build_i18n', None))


### PR DESCRIPTION
In setup.py it now also calls generate_atlases.py

I have not really tested this well.
It does seem to run, but I haven't yet tried it in the same environment that setup.py usually runs in.