### PR TITLE
solve pycodestyle

### DIFF
--- a/horizons/engine/generate_atlases.py
+++ b/horizons/engine/generate_atlases.py
@@ -63,6 +63,7 @@ class DummyFife:
 # TODO We can probably remove the type ignore in the next release of typeshed/mypy
 #      See https://github.com/python/typeshed/commit/08ac3b7742f1fd55f801ac66d7517cf60aa471d6
 
+
 import horizons.globals # isort:skip
 horizons.globals.fife = DummyFife() # type: ignore
 

--- a/setup.py
+++ b/setup.py
@@ -231,8 +231,6 @@ class _build_i18n(distutils.cmd.Command):
 		self.generate_atlases(2048)
 
 
-
-
 build.sub_commands.append(('build_i18n', None))
 
 cmdclass = {


### PR DESCRIPTION
horizons/engine/generate_atlases.py:66:1: E305 expected 2 blank lines after class or function definition, found 1
setup.py:236:1: E303 too many blank lines (4)