### PR TITLE
make windows starter file runnable from anywhere

### DIFF
--- a/run_uh.bat
+++ b/run_uh.bat
@@ -1,22 +1,23 @@
 @echo off
+
 echo Starting Unknown Horizons
 if '%1' == '--debug' goto debugMode
 if '%1' == '--help' goto help
 
 echo output will be written to logfile "unknownhorizons-DATETIME.log"
-IF EXIST ..\python\python.exe (
-  ..\python\python.exe run_uh.py --debug-log-only
+IF EXIST %~dp0..\python\python.exe (
+  %~dp0..\python\python.exe %~dp0run_uh.py --debug-log-only
 ) ELSE (
-  run_uh.py --debug-log-only
+  %~dp0run_uh.py --debug-log-only
 )
 pause
 goto:EOF
 
 :debugMode
-IF EXIST ..\python\python_d.exe (
-  ..\python\python_d.exe run_uh.py --debug-log-only
+IF EXIST %~dp0..\python\python_d.exe (
+  %~dp0..\python\python_d.exe run_uh.py --debug-log-only
 ) ELSE (
-  run_uh.py --debug-log-only
+  %~dp0run_uh.py --debug-log-only
 )
 if errorlevel 1 (echo.
 echo Error! Please check if you have Python Debug installed!


### PR DESCRIPTION
The file run_uh.bat required you to be in the same directory as that file to be able to run it.

This makes sure that all paths are relative to the run_uh.bat file