### PR TITLE
Use UTF-8 for constants.py

### DIFF
--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ###################################################
 # Copyright (C) 2008-2017 The Unknown Horizons Team
 # team@unknown-horizons.org


### PR DESCRIPTION
Some of the names (etc) use non-ASCII characters.
Let's use UTF-8 here.