### PR TITLE
name github issues as first help channel

### DIFF
--- a/run_uh.py
+++ b/run_uh.py
@@ -184,7 +184,7 @@ def excepthook_creator(outfilename):
 		print(T('We are very sorry for this and want to fix the underlying error.'))
 		print(T('In order to do this, we need the information from the logfile:'))
 		print(outfilename)
-		print(T('Please give it to us via IRC or our forum, for both see http://unknown-horizons.org .'))
+		print(T('Please give it to us via Github bug tracker, Discord or IRC; see http://unknown-horizons.org/support/'))
 	return excepthook
 
 


### PR DESCRIPTION
Most users won't stay in IRC long enough for us to see and answer their problems.
It is better to mention github issues and discord first so that will be the first place they'll go