### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class _build_i18n(distutils.cmd.Command):
 	def generate_mo_files(self, domain, po_dir):
 		if not os.path.isdir(po_dir):
 			return []
-		po_files = glob.glob("{}/*.po".format(po_dir))
+		po_files = sorted(glob.glob("{}/*.po".format(po_dir)))
 		if po_files and not find_executable('msgfmt'):
 			raise RuntimeError(
 				"Can't generate language files, needs msgfmt. "


### PR DESCRIPTION
Sort input file list
so that lang/stats.json builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.