### PR TITLE
replace deprecated to distro package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 coverage==4.4.1
 coveralls==1.1
 crayons==0.1.2
+distro
 future==0.16.0
 greenlet==0.4.15
 isort==4.3.4

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ from distutils.core import setup
 from distutils.spawn import find_executable
 from shutil import copytree, rmtree
 
+import distro
+
 import horizons
 from horizons.constants import VERSION
 from horizons.ext import polib
@@ -39,7 +41,7 @@ from horizons.ext import polib
 # Ensure we are in the correct directory
 os.chdir(os.path.realpath(os.path.dirname(__file__)))
 
-if platform.dist()[0].lower() in ('debian', 'ubuntu'):
+if distro.linux_distribution(full_distribution_name=False)[0] in ('debian', 'mint', 'ubuntu'):
 	executable_path = 'games'
 else:
 	executable_path = 'bin'


### PR DESCRIPTION
platform.dist()[0].lower() will be deprecated beginning with Python 3.7.
replace with distro.linux_distribution(full_distribution_name=False)[0] 