### PR TITLE
Sort input file lists

### DIFF
--- a/horizons/util/loaders/actionsetloader.py
+++ b/horizons/util/loaders/actionsetloader.py
@@ -47,7 +47,7 @@ class ActionSetLoader:
 	def _find_action_sets(cls, Dir):
 		"""Traverses recursively starting from dir to find action sets.
 		It is similar to os.walk, but more optimized for this use case."""
-		for entry in os.listdir(Dir):
+		for entry in sorted(os.listdir(Dir)):
 			full_path = os.path.join(Dir, entry)
 			if entry.startswith("as_"):
 				cls.action_sets[entry] = GeneralLoader._load_action(full_path)

--- a/horizons/util/loaders/loader.py
+++ b/horizons/util/loaders/loader.py
@@ -141,5 +141,5 @@ class GeneralLoader:
 		Discards everything else that we found living there in the past.
 		"""
 		junk = set(('.DS_Store', ))
-		return [d for d in os.listdir(directory)
+		return [d for d in sorted(os.listdir(directory))
 		          if d not in junk]

--- a/horizons/util/loaders/tilesetloader.py
+++ b/horizons/util/loaders/tilesetloader.py
@@ -47,7 +47,7 @@ class TileSetLoader:
 	def _find_tile_sets(cls, dir):
 		"""Traverses recursively starting from dir to find action sets.
 		It is similar to os.walk, but more optimized for this use case."""
-		for entry in os.listdir(dir):
+		for entry in sorted(os.listdir(dir)):
 			full_path = os.path.join(dir, entry)
 			if entry.startswith("ts_"):
 				cls.tile_sets[entry] = GeneralLoader._load_action(full_path)


### PR DESCRIPTION
Sort input file lists
so that `actionsets.json` and `tilesets.json` build in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.