### PR TITLE
generate_atlases: dont fail deleting files

### DIFF
--- a/horizons/engine/generate_atlases.py
+++ b/horizons/engine/generate_atlases.py
@@ -401,10 +401,13 @@ class AtlasGenerator:
 
 		# delete everything
 		for path in paths:
-			if not os.path.exists(path):
-				continue
 			cls.log.info('Deleting %s', path)
-			os.unlink(path)
+			try:
+				os.unlink(path)
+			except FileNotFoundError:
+				# file was already gone
+				# and that is the state we wanted anyway
+				pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
dont fail deleting files in `generate_atlases.py` if the files are already gone.

Without this patch, build on 1-core VMs sometimes failed with
```
 intltool-merge -d po/uh/ content/packages/unknown-horizons.desktop.in build/share/applications/unknown-horizons.desktop
 Merging translations into build/share/applications/unknown-horizons.desktop.
 + python3 horizons/engine/generate_atlases.py 2048
 Traceback (most recent call last):
   File "horizons/engine/generate_atlases.py", line 427, in <module>
     AtlasGenerator.clear_everything()
   File "horizons/engine/generate_atlases.py", line 407, in clear_everything
     os.unlink(path)
 FileNotFoundError: [Errno 2] No such file or directory: '/home/abuild/.cache/unknown-horizons/atlas-metadata.cache'
```

This PR was done while working on reproducible builds for openSUSE.