### PR TITLE
Skip update check for development builds

### DIFF
--- a/horizons/util/checkupdates.py
+++ b/horizons/util/checkupdates.py
@@ -1,5 +1,5 @@
 # ###################################################
-# Copyright (C) 2008-2017 The Unknown Horizons Team
+# Copyright (C) 2008-2020 The Unknown Horizons Team
 # team@unknown-horizons.org
 # This file is part of Unknown Horizons.
 #
@@ -77,6 +77,10 @@ def check_for_updates():
 	"""
 	Check if there's a new version, returns the data from the server, otherwise None.
 	"""
+	# do not check on development builds
+	if VERSION.IS_DEV_VERSION:
+		return
+
 	# skip check for platforms that have proper package managements
 	if platform.system() not in ('Windows', 'Darwin') and is_system_installed():
 		return


### PR DESCRIPTION
Applied update check to release builds only, since comparing release and git version is unreliable in its current implementation.

The update checker currently compares the string "2019.1" (release) against "2019" (latest git version) and hence the git version is always treated as the older build and the wrong update notification popping up on each launch.