### PR TITLE
Improve support for Flatpak

### DIFF
--- a/content/packages/unknown-horizons.appdata.xml
+++ b/content/packages/unknown-horizons.appdata.xml
@@ -39,4 +39,7 @@
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
+  <releases>
+   <release version="2019.1" date="2019-01-12"/>
+  </releases>
 </component>

--- a/content/packages/unknown-horizons.appdata.xml
+++ b/content/packages/unknown-horizons.appdata.xml
@@ -12,7 +12,7 @@
   </description>
   <screenshots>
     <screenshot>
-      <image>http://unknown-horizons.org/static/screenshots/2019-01-11.23-36-47.502394.png</image>
+      <image>https://unknown-horizons.org/static/screenshots/2019-01-11.23-36-47.502394.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">http://unknown-horizons.org/</url>

--- a/run_uh.py
+++ b/run_uh.py
@@ -159,7 +159,7 @@ def get_content_dir_parent_path():
 	# Unknown Horizons.app/Contents/Resources/contents
 	options.append(os.getcwd())
 	# Try often-used paths on Linux.
-	for path in ('/usr/share/games', '/usr/share', '/usr/local/share/games', '/usr/local/share'):
+	for path in ('/app/share', '/usr/share/games', '/usr/share', '/usr/local/share/games', '/usr/local/share'):
 		options.append(os.path.join(path, 'unknown-horizons'))
 
 	for path in options:


### PR DESCRIPTION
Here are 3 patches improving the flatpak support:
 * (bytefix) Use https instead of http for the screenshot
 * Add the latest release version in the appstream metadata
 * Add the Flatpak prefix for the application