### PR TITLE
fixs for Phyton 3.9

### DIFF
--- a/horizons/util/loaders/jsondecoder.py
+++ b/horizons/util/loaders/jsondecoder.py
@@ -37,4 +37,4 @@ class JsonDecoder:
 			return newdict
 
 		with open(path, "r") as f:
-			return json.load(f, encoding="ascii", object_hook=_decode_dict)
+			return json.load(f, object_hook=_decode_dict)

--- a/horizons/util/preloader.py
+++ b/horizons/util/preloader.py
@@ -79,9 +79,9 @@ class PreloadingThread(threading.Thread):
 		"""
 		self.lock.acquire()
 		# wait until it finished its current action
-		if self.isAlive():
+		if self.is_alive():
 			self.join()
-			assert not self.isAlive()
+			assert not self.is_alive()
 		else:
 			try:
 				self.lock.release()


### PR DESCRIPTION
* fix TypeError, see #2954
* The isAlive() function is deprecated and was change to is_alive().
>The isAlive() method of threading.Thread has been removed. It was deprecated since Python 3.8. Use is_alive() instead. (Contributed by Dong-hee Na in bpo-37804.)

https://docs.python.org/3.9/whatsnew/3.9.html#removed