### PR TITLE
Rename instances of `collections.Iterable` into `collections.abc.Iterable`

### DIFF
--- a/horizons/ai/aiplayer/combat/unitmanager.py
+++ b/horizons/ai/aiplayer/combat/unitmanager.py
@@ -151,7 +151,7 @@ class UnitManager:
 		"""
 		Rule stating that ship has to be in any of given states.
 		"""
-		if not isinstance(ship_states, collections.Iterable):
+		if not isinstance(ship_states, collections.abc.Iterable):
 			ship_states = (ship_states,)
 		return lambda ship: (state_dict[ship] in ship_states)
 
@@ -178,7 +178,7 @@ class UnitManager:
 		@param rules: conditions each ship has to meet (AND)
 		@type rules: iterable of lambda(ship) or single lambda(ship)
 		"""
-		if not isinstance(rules, collections.Iterable):
+		if not isinstance(rules, collections.abc.Iterable):
 			rules = (rules,)
 		return [ship for ship in ships if all((rule(ship) for rule in rules))]
 


### PR DESCRIPTION
Compatibility fix for `Python 3.10` as per note below.
> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working