### PR TITLE
Fix #2960: Generate PEP-440 compatible devbuild version for setuptools

### DIFF
--- a/horizons/constants.py
+++ b/horizons/constants.py
@@ -55,9 +55,8 @@ def get_git_version():
 			git = "git.exe"
 
 		# Note that this uses glob patterns, not regular expressions.
-		# TAG_STRUCTURE = "20[0-9][0-9].[0-9]*"
-		# describe = [git, "describe", "--tags", TAG_STRUCTURE]
-		describe = [git, "describe", "--tags"]
+		TAG_STRUCTURE = "20[0-9][0-9].[0-9]*"
+		describe = [git, "describe", "--tags", "--match", TAG_STRUCTURE]
 		git_string = subprocess.check_output(describe, cwd=uh_path, universal_newlines=True).rstrip('\n')
 		return git_string
 	except (subprocess.CalledProcessError, RuntimeError):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import glob
 import json
 import os
 import platform
+import re
 import sys
 from distutils.command.build import build
 from distutils.core import setup
@@ -239,9 +240,18 @@ cmdclass = {
 	'build_i18n': _build_i18n,
 }
 
+
+def _get_pep440_compliant_version(git_describe_output):
+	pattern = r'(20[\d]{2}\.[\d]+)(?:-([\d]+)-g[0-f]+)?'
+	if '-g' in git_describe_output:
+		return re.sub(pattern, r'\1.dev\2', git_describe_output)  # git revision count since tag
+	else:
+		return re.sub(pattern, r'\1', git_describe_output)  # just the tag itself, no suffix
+
+
 setup(
 	name='UnknownHorizons',
-	version=VERSION.RELEASE_VERSION,
+	version=_get_pep440_compliant_version(VERSION.RELEASE_VERSION),
 	description='Realtime Economy Simulation and Strategy Game',
 	author='The Unknown Horizons Team',
 	author_email='team@unknown-horizons.org',

--- a/setup.py
+++ b/setup.py
@@ -236,20 +236,20 @@ class _build_i18n(distutils.cmd.Command):
 build.sub_commands.append(('build_i18n', None))
 
 cmdclass = {
-    'build_i18n': _build_i18n,
+	'build_i18n': _build_i18n,
 }
 
 setup(
-    name='UnknownHorizons',
-    version=VERSION.RELEASE_VERSION,
-    description='Realtime Economy Simulation and Strategy Game',
-    author='The Unknown Horizons Team',
-    author_email='team@unknown-horizons.org',
-    url='http://www.unknown-horizons.org',
-    packages=packages,
-    package_data=package_data,
-    data_files=data,
-    cmdclass=cmdclass)
+	name='UnknownHorizons',
+	version=VERSION.RELEASE_VERSION,
+	description='Realtime Economy Simulation and Strategy Game',
+	author='The Unknown Horizons Team',
+	author_email='team@unknown-horizons.org',
+	url='http://www.unknown-horizons.org',
+	packages=packages,
+	package_data=package_data,
+	data_files=data,
+	cmdclass=cmdclass)
 
 # after installation remove gitversion.txt
 if os.path.exists('.git'):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ from horizons.ext import polib
 # Ensure we are in the correct directory
 os.chdir(os.path.realpath(os.path.dirname(__file__)))
 
-if distro.linux_distribution(full_distribution_name=False)[0] in ('debian', 'mint', 'ubuntu'):
+if distro.id() in ('debian', 'linuxmint', 'ubuntu'):
 	executable_path = 'games'
 else:
 	executable_path = 'bin'


### PR DESCRIPTION
This is makeshift, but probably enough to fix the build-blocking issue.

Fixes part of #2960 (as far as the version is concerned).

Converting the entire build to a modern architecture would still be recommended.