### PR TITLE
Python Pillow 10 compatibility

### DIFF
--- a/horizons/util/atlasloading.py
+++ b/horizons/util/atlasloading.py
@@ -55,7 +55,7 @@ def generate_atlases():
 		window.maxsize(300, 150)
 
 		logo = Image.open(PATHS.UH_LOGO_FILE)
-		res_logo = logo.resize((116, 99), Image.ANTIALIAS)
+		res_logo = logo.resize((116, 99), Image.LANCZOS)
 		res_logo_image = ImageTk.PhotoImage(res_logo)
 		logo_label = tkinter.Label(window, image=res_logo_image)
 		logo_label.pack(side="left")


### PR DESCRIPTION
Game cannot be run on system with Pillow 10 installed because of unknown Image contant.
Image.ANTIALIAS was deprecated and removed from Pillow, now it uses only name LANCZOS which was used from Pillow version 5.0